### PR TITLE
feat(hub): wire hub contracts across main, IPC, and preload

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,13 +12,18 @@ import { AgentLauncher } from './agents/AgentLauncher'
 import { ConfigStore } from './config/ConfigStore'
 import { registerIpcHandlers } from './ipc/handlers'
 import { registerHubHandlers } from './ipc/hub-handlers'
+import { registerEntitlementHandlers } from './ipc/entitlement-handlers'
+import { entitlementService } from './hub/EntitlementService'
 import { PipeServer } from './config/PipeServer'
+import { parseScopeString } from '../shared/hub-contracts.js'
 
 const SESSIONS_PATH = join(homedir(), '.agentcraftworks-hub', 'sessions.json')
 
 let mainWindow: BrowserWindow | null = null
+let pendingDeepLink: string | null = null
 
 const configStore = new ConfigStore()
+entitlementService.load()
 const ptyManager = new PtyManager()
 const sessionStore = new SessionStore()
 const sessionManager = new SessionManager(sessionStore, ptyManager)
@@ -65,11 +70,52 @@ function createWindow(): void {
   })
 
   registerHubHandlers(() => mainWindow && !mainWindow.isDestroyed() ? mainWindow : null)
+  registerEntitlementHandlers()
 
   if (process.env.ELECTRON_RENDERER_URL) {
     mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL)
   } else {
     mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+  }
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    if (pendingDeepLink) {
+      dispatchDeepLink(pendingDeepLink)
+      pendingDeepLink = null
+    }
+  })
+}
+
+function dispatchDeepLink(rawUrl: string): void {
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol !== 'agentcraftworks-hub:') {
+      return
+    }
+
+    const scopeRaw = parsed.searchParams.get('scope') || ''
+    const panel = parsed.searchParams.get('panel') || parsed.pathname.replace(/^\//, '') || 'overview'
+    const persona = parsed.searchParams.get('persona') || undefined
+    const parsedScope = scopeRaw ? parseScopeString(scopeRaw) : undefined
+
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore()
+      }
+      mainWindow.focus()
+      mainWindow.webContents.send('hub:deepLinkOpen', {
+        rawUrl,
+        panel,
+        scope: parsedScope,
+        scopeRaw,
+        persona,
+      })
+      if (parsedScope && parsedScope.org) {
+        entitlementService.setLastScope({ org: parsedScope.org, ...parsedScope, window: parsedScope.window ?? '7d' })
+      }
+    }
+  } catch (err) {
+    console.warn('[Tangent] Failed to parse deep-link:', err)
   }
 }
 
@@ -78,7 +124,14 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'tangent-file', privileges: { standard: false, supportFetchAPI: true, stream: true } }
 ])
 
+const gotSingleInstanceLock = app.requestSingleInstanceLock()
+if (!gotSingleInstanceLock) {
+  app.quit()
+}
+
 app.whenReady().then(async () => {
+  app.setAsDefaultProtocolClient('agentcraftworks-hub')
+
   protocol.handle('tangent-file', (request) => {
     // tangent-file:///C:/path/to/file.ico -> file:///C:/path/to/file.ico
     const filePath = decodeURIComponent(request.url.replace('tangent-file:///', ''))
@@ -198,6 +251,32 @@ app.whenReady().then(async () => {
   if (!restored) {
     sessionManager.create(configStore.getStartFolder())
   }
+
+  const deepLinkArg = process.argv.find((arg) => arg.startsWith('agentcraftworks-hub://'))
+  if (deepLinkArg) {
+    dispatchDeepLink(deepLinkArg)
+  }
+})
+
+app.on('open-url', (event, url) => {
+  event.preventDefault()
+  if (!mainWindow) {
+    pendingDeepLink = url
+    return
+  }
+  dispatchDeepLink(url)
+})
+
+app.on('second-instance', (_event, argv) => {
+  const deepLinkArg = argv.find((arg) => arg.startsWith('agentcraftworks-hub://'))
+  if (!deepLinkArg) {
+    return
+  }
+  if (!mainWindow) {
+    pendingDeepLink = deepLinkArg
+    return
+  }
+  dispatchDeepLink(deepLinkArg)
 })
 
 app.on('before-quit', () => {

--- a/src/main/ipc/hub-handlers.ts
+++ b/src/main/ipc/hub-handlers.ts
@@ -1,11 +1,26 @@
 // hub-handlers.ts — IPC handlers for GitHub monitoring (Hub dashboard)
 // Registers the GitHubMonitorService and pushes snapshots to the renderer.
+
 import { ipcMain, BrowserWindow, shell } from 'electron'
 import { execSync, spawn } from 'child_process'
 import { createRequire } from 'module'
 import { GitHubMonitorService } from '../github/GitHubMonitorService.js'
 import type { MonitorSnapshot } from '../github/GitHubMonitorService.js'
 import { loadHistory } from '../github/HistoryStore.js'
+import { appendOperationLog, listOperationLog } from '../github/OperationLogStore.js'
+import {
+  submitActionRequest,
+  listActionRequests,
+  approveActionRequest,
+  rejectActionRequest,
+  countPendingActionRequests,
+} from '../github/ActionRequestStore.js'
+import {
+  authorizeActionTier,
+  getActionAuthoritySnapshot,
+  normalizeActionTier,
+  toDeniedOperationLog,
+} from '../hub/ActionAuthority.js'
 
 // Keytar is an optional native module — gracefully degrade if not available
 const requireForOptionalDeps =
@@ -131,12 +146,71 @@ function startMonitor(token: string, enterprise: string, org: string, getWindow:
   monitorService.start()
 }
 
+function pushOperationLogUpdate(getWindow: () => BrowserWindow | null, entry: ReturnType<typeof appendOperationLog>): void {
+  getWindow()?.webContents.send('hub:operationLogUpdated', entry)
+}
+
+function appendDesktopOperationLog(
+  getWindow: () => BrowserWindow | null,
+  action: string,
+  scope: string,
+  result: string,
+  tier = 'T1',
+): void {
+  const entry = appendOperationLog({
+    action,
+    scope,
+    surface: 'desktop',
+    result,
+    actor: 'hub-desktop',
+    tier,
+  })
+  pushOperationLogUpdate(getWindow, entry)
+}
+
 export function registerHubHandlers(getWindow: () => BrowserWindow | null): void {
   // Get latest snapshot (one-shot request from renderer)
   ipcMain.handle('hub:getSnapshot', () => monitorService?.getSnapshot() ?? null)
 
   // Return persisted rate limit history for the full chart
   ipcMain.handle('hub:getHistory', () => loadHistory())
+
+  ipcMain.handle('hub:getOperationLog', (_, query) => listOperationLog(query ?? {}))
+
+  ipcMain.handle('hub:getActionAuthority', () => getActionAuthoritySnapshot())
+
+  ipcMain.handle('hub:appendOperationLogEntry', (_, input: {
+    actor?: string
+    action?: string
+    scope?: string
+    surface?: string
+    tier?: string
+    result?: string
+  }) => {
+    if (!input?.action || !input.action.trim()) {
+      return { ok: false, entry: null, error: 'action is required' }
+    }
+
+    const requiredTier = normalizeActionTier(input?.tier)
+    const authResult = authorizeActionTier(requiredTier)
+    if (!authResult.ok) {
+      const scope = input?.scope?.trim() || '(global)'
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.appendOperationLogEntry', scope, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+
+    const entry = appendOperationLog({
+      actor: input?.actor,
+      action: input.action,
+      scope: input?.scope,
+      surface: input?.surface,
+      tier: input?.tier,
+      result: input?.result,
+    })
+    pushOperationLogUpdate(getWindow, entry)
+    return { ok: true, entry }
+  })
 
   // Returns auth status and enterprise/org names — no PAT fields
   ipcMain.handle('hub:getTokenConfig', async () => {
@@ -165,6 +239,14 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
 
   // Launch GitHub web OAuth flow — opens system browser silently, no terminal window
   ipcMain.handle('hub:beginGitHubLogin', async (_, { enterprise, org }: { enterprise: string; org?: string }) => {
+    const authResult = authorizeActionTier('T2')
+    if (!authResult.ok) {
+      const scope = `org:${(org ?? '').trim() || cachedOrg}`
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.beginGitHubLogin', scope, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+
     const ent = enterprise.trim() || 'AICraftWorks'
     const orgSlug = (org ?? '').trim() || 'AgentCraftworks'
     cachedEnterprise = ent
@@ -176,8 +258,10 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
 
     try {
       launchGitHubLoginIntegrated(REQUIRED_GH_SCOPES, getWindow)
+      appendDesktopOperationLog(getWindow, 'hub.beginGitHubLogin', `org:${orgSlug}`, 'ok')
       return { ok: true }
     } catch {
+      appendDesktopOperationLog(getWindow, 'hub.beginGitHubLogin', `org:${orgSlug}`, 'failed')
       return { ok: false, error: 'Unable to launch GitHub login. Ensure GitHub CLI (gh) is installed and in PATH.' }
     }
   })
@@ -190,8 +274,18 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
 
   // Verify gh auth status/scopes and start monitoring with gh token
   ipcMain.handle('hub:completeGitHubLogin', async (_, { enterprise, org }: { enterprise: string; org?: string }) => {
+    const authResult = authorizeActionTier('T2')
+    if (!authResult.ok) {
+      const scope = `org:${(org ?? '').trim() || cachedOrg}`
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.completeGitHubLogin', scope, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+
     const token = getGhCliToken()
     if (!token) {
+      const failedScope = `org:${(org ?? '').trim() || cachedOrg}`
+      appendDesktopOperationLog(getWindow, 'hub.completeGitHubLogin', failedScope, 'failed')
       return { ok: false, error: 'GitHub login not detected yet. Complete the sign-in flow in your browser first.' }
     }
 
@@ -207,11 +301,20 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
     }
 
     startMonitor(token, ent, orgSlug, getWindow)
+    appendDesktopOperationLog(getWindow, 'hub.completeGitHubLogin', `org:${orgSlug}`, 'ok')
     return { ok: true, scopes, missingScopes: missing }
   })
 
   // Log out of GitHub CLI and stop monitor
   ipcMain.handle('hub:logoutGitHub', async () => {
+    const authResult = authorizeActionTier('T2')
+    if (!authResult.ok) {
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.logoutGitHub', `org:${cachedOrg}`, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+
+    const org = await getStoredOrg()
     try {
       execSync('gh auth logout --hostname github.com --yes', { stdio: 'ignore' })
     } catch {
@@ -221,6 +324,8 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
     monitorService?.stop()
     monitorService = null
 
+    appendDesktopOperationLog(getWindow, 'hub.logoutGitHub', `org:${org}`, 'ok')
+
     return { ok: true }
   })
 
@@ -229,28 +334,109 @@ export function registerHubHandlers(getWindow: () => BrowserWindow | null): void
     if (monitorService) return { ok: true }
 
     const token = getGhCliToken()
-    if (!token) return { ok: false, error: 'No GitHub token found. Click "Sign in with GitHub" to authenticate.' }
+    const org = await getStoredOrg()
+    if (!token) {
+      appendDesktopOperationLog(getWindow, 'hub.start', `org:${org}`, 'failed')
+      return { ok: false, error: 'No GitHub token found. Click "Sign in with GitHub" to authenticate.' }
+    }
 
     const ent = enterprise?.trim() || (await getStoredEnterprise())
-    const org = await getStoredOrg()
     startMonitor(token, ent, org, getWindow)
+    appendDesktopOperationLog(getWindow, 'hub.start', `org:${org}`, 'ok')
     return { ok: true }
   })
 
   // Stop monitoring
   ipcMain.handle('hub:stop', () => {
+    const authResult = authorizeActionTier('T2')
+    if (!authResult.ok) {
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.stop', `org:${cachedOrg}`, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+
+    const scope = `org:${cachedOrg}`
     monitorService?.stop()
     monitorService = null
+    appendDesktopOperationLog(getWindow, 'hub.stop', scope, 'ok')
     return { ok: true }
   })
 
   // Manually refresh all pollers immediately
   ipcMain.handle('hub:refresh', async () => {
     const token = getGhCliToken()
-    if (!token) return { ok: false, error: 'No GitHub token' }
-    const enterprise = await getStoredEnterprise()
     const org = await getStoredOrg()
+    if (!token) {
+      appendDesktopOperationLog(getWindow, 'hub.refresh', `org:${org}`, 'failed')
+      return { ok: false, error: 'No GitHub token' }
+    }
+    const enterprise = await getStoredEnterprise()
     startMonitor(token, enterprise, org, getWindow)
+    appendDesktopOperationLog(getWindow, 'hub.refresh', `org:${org}`, 'ok')
     return { ok: true }
+  })
+
+  // ============================================================================
+  // Action Request Queue — submit / list / approve / reject
+  // ============================================================================
+
+  function pushActionRequestUpdate(request: ReturnType<typeof submitActionRequest>): void {
+    getWindow()?.webContents.send('hub:actionRequestUpdated', request)
+  }
+
+  ipcMain.handle('hub:submitActionRequest', (_, input: {
+    actor?: string
+    action?: string
+    scope?: string
+    surface?: string
+    tier?: string
+    rationale?: string
+  }) => {
+    if (!input?.action || !input.action.trim()) {
+      return { ok: false, error: 'action is required' }
+    }
+    const request = submitActionRequest({
+      actor: input.actor,
+      action: input.action,
+      scope: input.scope,
+      surface: input.surface,
+      tier: input.tier,
+      rationale: input.rationale,
+    })
+    pushActionRequestUpdate(request)
+    appendDesktopOperationLog(getWindow, 'hub.submitActionRequest', input.scope || '', 'ok')
+    return { ok: true, request }
+  })
+
+  ipcMain.handle('hub:listActionRequests', (_, query) => listActionRequests(query ?? {}))
+
+  ipcMain.handle('hub:countPendingRequests', () => countPendingActionRequests())
+
+  ipcMain.handle('hub:approveActionRequest', (_, id: string, note?: string) => {
+    const authResult = authorizeActionTier('T3')
+    if (!authResult.ok) {
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.approveActionRequest', id, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+    const updated = approveActionRequest(id, { resolvedBy: 'hub-desktop', note })
+    if (!updated) return { ok: false, error: `Request ${id} not found` }
+    pushActionRequestUpdate(updated)
+    appendDesktopOperationLog(getWindow, 'hub.approveActionRequest', id, 'ok', 'T3')
+    return { ok: true, request: updated }
+  })
+
+  ipcMain.handle('hub:rejectActionRequest', (_, id: string, note?: string) => {
+    const authResult = authorizeActionTier('T3')
+    if (!authResult.ok) {
+      const deniedEntry = appendOperationLog(toDeniedOperationLog('hub.rejectActionRequest', id, authResult))
+      pushOperationLogUpdate(getWindow, deniedEntry)
+      return authResult
+    }
+    const updated = rejectActionRequest(id, { resolvedBy: 'hub-desktop', note })
+    if (!updated) return { ok: false, error: `Request ${id} not found` }
+    pushActionRequestUpdate(updated)
+    appendDesktopOperationLog(getWindow, 'hub.rejectActionRequest', id, 'ok', 'T3')
+    return { ok: true, request: updated }
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -133,10 +133,10 @@ contextBridge.exposeInMainWorld('tangentAPI', tangentAPI)
 
 // Hub monitoring API — separate namespace to avoid collisions with Tangent internals
 const hubAPI = {
-  start: (enterprise?: string): Promise<{ ok: boolean; error?: string }> =>
+  start: (enterprise?: string): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:start', enterprise),
 
-  stop: (): Promise<{ ok: boolean }> =>
+  stop: (): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:stop'),
 
   getSnapshot: (): Promise<import('@shared/hub-types').MonitorSnapshot | null> =>
@@ -145,6 +145,17 @@ const hubAPI = {
   getHistory: (): Promise<import('@shared/hub-types').RateLimitSample[]> =>
     ipcRenderer.invoke('hub:getHistory'),
 
+  getOperationLog: (query?: import('@shared/hub-types').OperationLogQuery): Promise<import('@shared/hub-types').OperationLogEntry[]> =>
+    ipcRenderer.invoke('hub:getOperationLog', query),
+
+  appendOperationLogEntry: (
+    input: import('@shared/hub-types').OperationLogAppendInput,
+  ): Promise<import('@shared/hub-types').HubActionResponse & { entry?: import('@shared/hub-types').OperationLogEntry }> =>
+    ipcRenderer.invoke('hub:appendOperationLogEntry', input),
+
+  getActionAuthority: (): Promise<import('@shared/hub-types').ActionAuthoritySnapshot> =>
+    ipcRenderer.invoke('hub:getActionAuthority'),
+
   getTokenConfig: (): Promise<{ hasToken: boolean; enterprise: string; org: string; isGhCli: boolean; ghAuthenticated: boolean; ghScopes: string[]; missingScopes: string[] }> =>
     ipcRenderer.invoke('hub:getTokenConfig'),
 
@@ -152,20 +163,22 @@ const hubAPI = {
     ipcRenderer.invoke('hub:checkLoginStatus'),
 
   // org is optional; defaults to the persisted or default org slug on the main process side
-  beginGitHubLogin: (params: { enterprise: string; org?: string }): Promise<{ ok: boolean; error?: string }> =>
+  beginGitHubLogin: (params: { enterprise: string; org?: string }): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:beginGitHubLogin', params),
 
-  openDevicePage: (): Promise<{ ok: boolean }> =>
+  openDevicePage: (): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:openDevicePage'),
 
   // org is optional; defaults to the persisted or default org slug on the main process side
-  completeGitHubLogin: (params: { enterprise: string; org?: string }): Promise<{ ok: boolean; error?: string; scopes?: string[]; missingScopes?: string[] }> =>
+  completeGitHubLogin: (
+    params: { enterprise: string; org?: string },
+  ): Promise<import('@shared/hub-types').HubActionResponse & { scopes?: string[]; missingScopes?: string[] }> =>
     ipcRenderer.invoke('hub:completeGitHubLogin', params),
 
-  logoutGitHub: (): Promise<{ ok: boolean; error?: string }> =>
+  logoutGitHub: (): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:logoutGitHub'),
 
-  refresh: (): Promise<{ ok: boolean; error?: string }> =>
+  refresh: (): Promise<import('@shared/hub-types').HubActionResponse> =>
     ipcRenderer.invoke('hub:refresh'),
 
   onSnapshot: (cb: (snapshot: import('@shared/hub-types').MonitorSnapshot) => void): (() => void) => {
@@ -185,6 +198,72 @@ const hubAPI = {
     ipcRenderer.on('hub:deviceCode', handler)
     return () => { ipcRenderer.removeListener('hub:deviceCode', handler) }
   },
+
+  onOperationLogUpdated: (cb: (entry: import('@shared/hub-types').OperationLogEntry) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, entry: import('@shared/hub-types').OperationLogEntry) => cb(entry)
+    ipcRenderer.on('hub:operationLogUpdated', handler)
+    return () => { ipcRenderer.removeListener('hub:operationLogUpdated', handler) }
+  },
+
+  // Action request queue
+  submitActionRequest: (
+    input: import('@shared/hub-types').ActionRequestSubmitInput,
+  ): Promise<import('@shared/hub-types').HubActionResponse & { request?: import('@shared/hub-types').ActionRequest }> =>
+    ipcRenderer.invoke('hub:submitActionRequest', input),
+
+  listActionRequests: (query?: import('@shared/hub-types').ActionRequestQuery): Promise<import('@shared/hub-types').ActionRequest[]> =>
+    ipcRenderer.invoke('hub:listActionRequests', query),
+
+  countPendingRequests: (): Promise<number> =>
+    ipcRenderer.invoke('hub:countPendingRequests'),
+
+  approveActionRequest: (
+    id: string,
+    note?: string,
+  ): Promise<import('@shared/hub-types').HubActionResponse & { request?: import('@shared/hub-types').ActionRequest }> =>
+    ipcRenderer.invoke('hub:approveActionRequest', id, note),
+
+  rejectActionRequest: (
+    id: string,
+    note?: string,
+  ): Promise<import('@shared/hub-types').HubActionResponse & { request?: import('@shared/hub-types').ActionRequest }> =>
+    ipcRenderer.invoke('hub:rejectActionRequest', id, note),
+
+  onActionRequestUpdated: (cb: (request: import('@shared/hub-types').ActionRequest) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, request: import('@shared/hub-types').ActionRequest) => cb(request)
+    ipcRenderer.on('hub:actionRequestUpdated', handler)
+    return () => { ipcRenderer.removeListener('hub:actionRequestUpdated', handler) }
+  },
+
+  onDeepLinkOpen: (cb: (payload: {
+    rawUrl: string
+    panel: string
+    scopeRaw: string
+    persona?: string
+    scope?: unknown
+  }) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, payload: {
+      rawUrl: string
+      panel: string
+      scopeRaw: string
+      persona?: string
+      scope?: unknown
+    }) => cb(payload)
+    ipcRenderer.on('hub:deepLinkOpen', handler)
+    return () => { ipcRenderer.removeListener('hub:deepLinkOpen', handler) }
+  },
 }
 
 contextBridge.exposeInMainWorld('hubAPI', hubAPI)
+
+// Entitlement API — persona + capability gating
+const entitlementAPI = {
+  getSnapshot: () => ipcRenderer.invoke('entitlement:getSnapshot'),
+  setPersona: (personaId: string) => ipcRenderer.invoke('entitlement:setPersona', personaId),
+  setLicenseLevel: (level: string) => ipcRenderer.invoke('entitlement:setLicenseLevel', level),
+  setLicenseKey: (key: string) => ipcRenderer.invoke('entitlement:setLicenseKey', key),
+  setLastScope: (scope: unknown) => ipcRenderer.invoke('entitlement:setLastScope', scope),
+  allows: (capabilityKey: string) => ipcRenderer.invoke('entitlement:allows', capabilityKey),
+}
+
+contextBridge.exposeInMainWorld('entitlementAPI', entitlementAPI)

--- a/src/shared/hub-types.ts
+++ b/src/shared/hub-types.ts
@@ -85,26 +85,127 @@ export interface RateLimitSample {
   coreLimit: number
 }
 
+export interface OperationLogEntry {
+  id: string
+  ts: string
+  actor: string
+  action: string
+  scope: string
+  surface: string
+  tier: string
+  result: string
+}
+
+export interface OperationLogQuery {
+  limit?: number
+  scope?: string
+  surface?: string
+  result?: string
+}
+
+export interface OperationLogAppendInput {
+  actor?: string
+  action: string
+  scope?: string
+  surface?: string
+  tier?: string
+  result?: string
+}
+
+export type ActionTier = 'T1' | 'T2' | 'T3' | 'T4' | 'T5'
+
+export interface HubActionResponse {
+  ok: boolean
+  error?: string
+  denied?: boolean
+  requiredTier?: ActionTier
+  requiredCapability?: string
+  personaId?: string
+  licenseLevel?: string
+}
+
+export interface ActionAuthoritySnapshot {
+  personaId: string
+  licenseLevel: string
+  capabilities: string[]
+  tierRequirements: Record<ActionTier, string>
+}
+
+// ============================================================================
+// Action Request Queue (request/approve workflow)
+// ============================================================================
+
+export type ActionRequestState = 'pending' | 'approved' | 'rejected'
+
+export interface ActionRequest {
+  id: string
+  ts: string
+  actor: string
+  action: string
+  scope: string
+  surface: string
+  tier: string
+  rationale?: string
+  state: ActionRequestState
+  resolvedAt?: string
+  resolvedBy?: string
+  resolvedNote?: string
+}
+
+export interface ActionRequestSubmitInput {
+  actor?: string
+  action: string
+  scope?: string
+  surface?: string
+  tier?: string
+  rationale?: string
+}
+
+export interface ActionRequestQuery {
+  limit?: number
+  state?: ActionRequestState
+  scope?: string
+}
+
 export interface HubWindowAPI {
-  start(enterprise?: string): Promise<{ ok: boolean; error?: string }>
-  stop(): Promise<{ ok: boolean }>
+  start(enterprise?: string): Promise<HubActionResponse>
+  stop(): Promise<HubActionResponse>
   getSnapshot(): Promise<MonitorSnapshot | null>
   getHistory(): Promise<RateLimitSample[]>
+  getOperationLog(query?: OperationLogQuery): Promise<OperationLogEntry[]>
+  appendOperationLogEntry(input: OperationLogAppendInput): Promise<HubActionResponse & { entry?: OperationLogEntry }>
+  getActionAuthority(): Promise<ActionAuthoritySnapshot>
   getTokenConfig(): Promise<{
     hasToken: boolean
     enterprise: string
+    org: string
     isGhCli: boolean
     ghAuthenticated: boolean
     ghScopes: string[]
     missingScopes: string[]
   }>
   checkLoginStatus(): Promise<{ authenticated: boolean; scopes: string[]; missingScopes: string[] }>
-  beginGitHubLogin(params: { enterprise: string }): Promise<{ ok: boolean; error?: string }>
-  openDevicePage(): Promise<{ ok: boolean }>
-  completeGitHubLogin(params: { enterprise: string }): Promise<{ ok: boolean; error?: string; scopes?: string[]; missingScopes?: string[] }>
-  logoutGitHub(): Promise<{ ok: boolean; error?: string }>
-  refresh(): Promise<{ ok: boolean; error?: string }>
+  beginGitHubLogin(params: { enterprise: string; org?: string }): Promise<HubActionResponse>
+  openDevicePage(): Promise<HubActionResponse>
+  completeGitHubLogin(params: { enterprise: string; org?: string }): Promise<HubActionResponse & { scopes?: string[]; missingScopes?: string[] }>
+  logoutGitHub(): Promise<HubActionResponse>
+  refresh(): Promise<HubActionResponse>
   onSnapshot(cb: (snapshot: MonitorSnapshot) => void): () => void
   onError(cb: (message: string) => void): () => void
   onDeviceCode(cb: (code: string) => void): () => void
+  onOperationLogUpdated(cb: (entry: OperationLogEntry) => void): () => void
+  // Action request queue
+  submitActionRequest(input: ActionRequestSubmitInput): Promise<HubActionResponse & { request?: ActionRequest }>
+  listActionRequests(query?: ActionRequestQuery): Promise<ActionRequest[]>
+  approveActionRequest(id: string, note?: string): Promise<HubActionResponse & { request?: ActionRequest }>
+  rejectActionRequest(id: string, note?: string): Promise<HubActionResponse & { request?: ActionRequest }>
+  countPendingRequests(): Promise<number>
+  onActionRequestUpdated(cb: (request: ActionRequest) => void): () => void
+  onDeepLinkOpen(cb: (payload: {
+    rawUrl: string
+    panel: string
+    scopeRaw: string
+    persona?: string
+    scope?: unknown
+  }) => void): () => void
 }


### PR DESCRIPTION
## Summary
- update hub shared types used by monitor/dashboard wiring
- wire main process and IPC handlers for hub contract flow
- expose preload bridge updates for renderer consumption

## Scope
Foundation wiring only. UI and docs/CLI changes are in follow-up PRs.