### PR TITLE
feat: Rate Governor, Handoff, and Squad Coordinator panels

### DIFF
--- a/src/main/github/GitHubMonitorService.ts
+++ b/src/main/github/GitHubMonitorService.ts
@@ -34,6 +34,9 @@ export interface MonitorSnapshot {
   auditScope: 'enterprise' | 'org' | null
   auditLogError?: string
   ghawWorkflows: GhawWorkflowData | null
+  rateGovernor: import('@shared/hub-types').HubRateGovernorData | null
+  handoffs: import('@shared/hub-types').HubHandoffData | null
+  squadState: import('@shared/hub-types').HubSquadData | null
   lastUpdated: Record<string, number>
 }
 
@@ -66,6 +69,9 @@ export class GitHubMonitorService extends EventEmitter {
     hourlyBuckets: [],
     auditScope: null,
     ghawWorkflows: null,
+    rateGovernor: null,
+    handoffs: null,
+    squadState: null,
     lastUpdated: {},
   }
 

--- a/src/renderer/components/dashboard/HandoffFlowPanel.tsx
+++ b/src/renderer/components/dashboard/HandoffFlowPanel.tsx
@@ -1,0 +1,137 @@
+// HandoffFlowPanel.tsx — Agent-to-agent handoff flow visualization
+import type { HubHandoffData, HubHandoffEntry, HandoffStatus, HandoffPriority } from '@shared/hub-types'
+import { RefreshCw, ArrowRight, GitPullRequest } from 'lucide-react'
+
+interface Props {
+  data: HubHandoffData | null
+  onRefresh: () => void
+}
+
+const statusColors: Record<HandoffStatus, { bg: string; text: string; label: string }> = {
+  pending: { bg: 'bg-blue-500/20', text: 'text-blue-400', label: 'Pending' },
+  active: { bg: 'bg-green-500/20', text: 'text-green-400', label: 'Active' },
+  completed: { bg: 'bg-white/10', text: 'text-white/60', label: 'Done' },
+  failed: { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Failed' },
+}
+
+const priorityColors: Record<HandoffPriority, string> = {
+  critical: 'text-red-400',
+  high: 'text-amber-400',
+  medium: 'text-blue-400',
+  low: 'text-white/40',
+}
+
+function HandoffCard({ handoff }: { handoff: HubHandoffEntry }) {
+  const status = statusColors[handoff.status]
+  const priColor = priorityColors[handoff.priority]
+  const age = handoff.created_at
+    ? `${Math.round((Date.now() - new Date(handoff.created_at).getTime()) / 60000)}m ago`
+    : ''
+
+  return (
+    <div className={`rounded-lg p-3 border border-white/5 ${status.bg}`} data-testid={`handoff-${handoff.handoff_id}`}>
+      {/* Agent flow */}
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className="text-white/80 text-xs font-mono truncate max-w-[100px]">{handoff.from_agent}</span>
+        <ArrowRight size={12} className="text-white/30 flex-shrink-0" />
+        <span className="text-white/80 text-xs font-mono truncate max-w-[100px]">{handoff.to_agent}</span>
+        <span className={`ml-auto text-[10px] font-medium ${status.text}`}>{status.label}</span>
+      </div>
+      {/* Task + metadata */}
+      <div className="text-[11px] text-white/50 truncate mb-1">{handoff.task}</div>
+      <div className="flex items-center gap-2 text-[10px]">
+        <span className={priColor}>{handoff.priority}</span>
+        <span className="text-white/30">{age}</span>
+        {handoff.sla_deadline && (
+          <span className="text-amber-400/70">SLA: {new Date(handoff.sla_deadline).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+        )}
+        {handoff.failure_reason && (
+          <span className="text-red-400 truncate max-w-[120px]">{handoff.failure_reason}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, color }: { label: string; value: string | number; color: string }) {
+  return (
+    <div className="text-center">
+      <div className={`text-lg font-bold tabular-nums ${color}`}>{value}</div>
+      <div className="text-[10px] text-white/40">{label}</div>
+    </div>
+  )
+}
+
+export function HandoffFlowPanel({ data, onRefresh }: Props) {
+  if (!data) {
+    return (
+      <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-handoff-flow">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+            <GitPullRequest size={14} /> Agent Handoffs
+          </div>
+          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        </div>
+        <div className="text-white/30 text-xs text-center py-6">No handoff data</div>
+      </div>
+    )
+  }
+
+  const { active, recent, stats } = data
+  const avgTime = stats.avgCompletionMs > 0 ? `${Math.round(stats.avgCompletionMs / 60000)}m` : '--'
+
+  return (
+    <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-handoff-flow">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+          <GitPullRequest size={14} /> Agent Handoffs
+        </div>
+        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-4 gap-3 mb-4 p-3 bg-white/5 rounded-lg" data-testid="handoff-stats">
+        <StatCard label="Active" value={stats.active} color="text-green-400" />
+        <StatCard label="Completed" value={stats.completed} color="text-white/80" />
+        <StatCard label="Failed" value={stats.failed} color={stats.failed > 0 ? 'text-red-400' : 'text-white/40'} />
+        <StatCard label="Avg Time" value={avgTime} color="text-blue-400" />
+      </div>
+
+      {/* Active handoffs */}
+      <div className="mb-3">
+        <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">
+          Active ({active.length})
+        </div>
+        {active.length === 0 ? (
+          <div className="text-white/20 text-xs text-center py-2">No active handoffs</div>
+        ) : (
+          <div className="space-y-2 max-h-40 overflow-y-auto">
+            {active.map((h) => <HandoffCard key={h.handoff_id} handoff={h} />)}
+          </div>
+        )}
+      </div>
+
+      {/* Recent completions */}
+      {recent.length > 0 && (
+        <div>
+          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">
+            Recent ({recent.length})
+          </div>
+          <div className="space-y-1.5 max-h-32 overflow-y-auto">
+            {recent.slice(0, 5).map((h) => <HandoffCard key={h.handoff_id} handoff={h} />)}
+          </div>
+        </div>
+      )}
+
+      {/* SLA compliance */}
+      {stats.slaComplianceRate > 0 && (
+        <div className="mt-3 text-[10px] text-white/30 text-right">
+          SLA compliance: <span className={stats.slaComplianceRate >= 95 ? 'text-green-400' : stats.slaComplianceRate >= 80 ? 'text-amber-400' : 'text-red-400'}>
+            {stats.slaComplianceRate}%
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/dashboard/HubDashboard.tsx
+++ b/src/renderer/components/dashboard/HubDashboard.tsx
@@ -10,6 +10,9 @@ import { TokenAuthPanel } from './TokenAuthPanel'
 import { OperationLogPanel } from './OperationLogPanel'
 import { ActionRequestPanel } from './ActionRequestPanel'
 import { WorkflowHealthPanel } from './WorkflowHealthPanel'
+import { RateGovernorPanel } from './RateGovernorPanel'
+import { HandoffFlowPanel } from './HandoffFlowPanel'
+import { SquadCoordinatorPanel } from './SquadCoordinatorPanel'
 import { RefreshCw, Loader, Settings, ShieldAlert } from 'lucide-react'
 import type { ActionRequest, ActionAuthoritySnapshot, OperationLogEntry } from '@shared/hub-types'
 import { buildDeepLink } from '@shared/hub-contracts'
@@ -257,6 +260,30 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
             <RateLimitPanel
               data={snapshot?.rateLimit ?? null}
               history={history}
+              onRefresh={refreshAll}
+            />
+          </div>
+
+          {/* Rate Governor — governance layer beside raw rate limit */}
+          <div className="xl:col-span-1">
+            <RateGovernorPanel
+              data={snapshot?.rateGovernor ?? null}
+              onRefresh={refreshAll}
+            />
+          </div>
+
+          {/* Agent Handoff Flow — full width */}
+          <div className="xl:col-span-2">
+            <HandoffFlowPanel
+              data={snapshot?.handoffs ?? null}
+              onRefresh={refreshAll}
+            />
+          </div>
+
+          {/* Squad Coordinator — full width */}
+          <div className="xl:col-span-2">
+            <SquadCoordinatorPanel
+              data={snapshot?.squadState ?? null}
               onRefresh={refreshAll}
             />
           </div>

--- a/src/renderer/components/dashboard/RateGovernorPanel.tsx
+++ b/src/renderer/components/dashboard/RateGovernorPanel.tsx
@@ -1,0 +1,156 @@
+// RateGovernorPanel.tsx — Traffic light zone, quota pools, priority tiers, circuit breakers
+import type { HubRateGovernorData } from '@shared/hub-types'
+import { RefreshCw, Shield, Zap } from 'lucide-react'
+
+interface Props {
+  data: HubRateGovernorData | null
+  onRefresh: () => void
+}
+
+const zoneColors = {
+  GREEN: { bg: 'bg-green-500', glow: 'shadow-green-500/40', text: 'text-green-400', label: 'Normal' },
+  AMBER: { bg: 'bg-amber-500', glow: 'shadow-amber-500/40', text: 'text-amber-400', label: 'Pressure' },
+  RED: { bg: 'bg-red-500', glow: 'shadow-red-500/40', text: 'text-red-400', label: 'Critical' },
+} as const
+
+const circuitLabels = {
+  CLOSED: { text: 'text-green-400', label: '●' },
+  PRE_EMPTIVE_OPEN: { text: 'text-amber-400', label: '◐' },
+  HALF_OPEN: { text: 'text-amber-400', label: '◑' },
+  OPEN: { text: 'text-red-400', label: '○' },
+} as const
+
+function QuotaBar({ label, remaining, total }: { label: string; remaining: number; total: number }) {
+  const pct = total > 0 ? (remaining / total) * 100 : 0
+  const color = pct > 40 ? 'bg-green-500' : pct > 15 ? 'bg-amber-500' : 'bg-red-500'
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs">
+        <span className="text-white/60">{label}</span>
+        <span className="text-white/80 tabular-nums">{remaining.toLocaleString()} / {total.toLocaleString()}</span>
+      </div>
+      <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full transition-all duration-500 ${color}`} style={{ width: `${Math.max(pct, 1)}%` }} />
+      </div>
+    </div>
+  )
+}
+
+function PriorityBadge({ tier, zone }: { tier: 'P0' | 'P1' | 'P2'; zone: 'GREEN' | 'AMBER' | 'RED' }) {
+  const status =
+    tier === 'P0' ? { label: 'Active', color: 'text-green-400' } :
+    tier === 'P1' ? (zone === 'RED' ? { label: 'Constrained', color: 'text-amber-400' } : { label: 'Active', color: 'text-green-400' }) :
+    zone === 'RED' ? { label: 'Parked', color: 'text-red-400' } :
+    zone === 'AMBER' ? { label: 'Throttled', color: 'text-amber-400' } :
+    { label: 'Active', color: 'text-green-400' }
+
+  return (
+    <div className="flex items-center justify-between text-xs" data-testid={`hub-priority-${tier.toLowerCase()}`}>
+      <span className="text-white/60 font-mono">{tier}</span>
+      <span className={`font-medium ${status.color}`}>{status.label}</span>
+    </div>
+  )
+}
+
+export function RateGovernorPanel({ data, onRefresh }: Props) {
+  if (!data) {
+    return (
+      <div className="bg-white/5 rounded-xl p-4 border border-white/10" data-testid="hub-rate-governor">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+            <Shield size={14} /> Rate Governor
+          </div>
+          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        </div>
+        <div className="text-white/30 text-xs text-center py-6">No rate governor data</div>
+      </div>
+    )
+  }
+
+  const { state, github, copilot, agents } = data
+  const zone = zoneColors[state.trafficLight]
+
+  return (
+    <div className="bg-white/5 rounded-xl p-4 border border-white/10" data-testid="hub-rate-governor">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+          <Shield size={14} /> Rate Governor
+        </div>
+        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+      </div>
+
+      {/* Traffic Light */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex gap-1.5">
+          {(['GREEN', 'AMBER', 'RED'] as const).map((z) => (
+            <div
+              key={z}
+              className={`w-5 h-5 rounded-full transition-all ${
+                z === state.trafficLight
+                  ? `${zoneColors[z].bg} ${zoneColors[z].glow} shadow-lg`
+                  : 'bg-white/10'
+              }`}
+              data-testid={`hub-zone-${z.toLowerCase()}`}
+            />
+          ))}
+        </div>
+        <div>
+          <span className={`text-lg font-bold ${zone.text}`} data-testid="hub-zone-label">{state.trafficLight}</span>
+          <span className="text-white/40 text-xs ml-2">{zone.label}</span>
+        </div>
+      </div>
+
+      {/* Quota Pools */}
+      <div className="space-y-2 mb-4" data-testid="hub-quota-pools">
+        <QuotaBar label="GitHub" remaining={github.windowRemaining} total={github.windowTotal} />
+        <QuotaBar label="Copilot" remaining={copilot.windowRemaining} total={copilot.windowTotal} />
+      </div>
+
+      {/* Priority Tiers */}
+      <div className="space-y-1.5 mb-4" data-testid="hub-priority-tiers">
+        <div className="text-[10px] text-white/40 uppercase tracking-wider">Priority Tiers</div>
+        <PriorityBadge tier="P0" zone={state.trafficLight} />
+        <PriorityBadge tier="P1" zone={state.trafficLight} />
+        <PriorityBadge tier="P2" zone={state.trafficLight} />
+      </div>
+
+      {/* Circuit Breakers */}
+      <div className="flex items-center gap-3 text-xs mb-3" data-testid="hub-circuits">
+        <span className="text-white/40">Circuits:</span>
+        <span className={circuitLabels[state.circuitStateByQuota.github].text}>
+          {circuitLabels[state.circuitStateByQuota.github].label} GitHub
+        </span>
+        <span className={circuitLabels[state.circuitStateByQuota.copilot].text}>
+          {circuitLabels[state.circuitStateByQuota.copilot].label} Copilot
+        </span>
+        {state.cascadeMode === 'sequential' && (
+          <span className="text-amber-400">◐ Sequential</span>
+        )}
+      </div>
+
+      {/* Agent Tokens (compact) */}
+      {agents.length > 0 && (
+        <div data-testid="hub-agent-tokens">
+          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-1">Agents ({agents.length})</div>
+          <div className="space-y-1 max-h-28 overflow-y-auto">
+            {agents.map((a) => {
+              const utilPct = a.reserved > 0 ? Math.round((a.used / a.reserved) * 100) : 0
+              return (
+                <div key={a.agentId} className="flex items-center justify-between text-[11px]">
+                  <span className="text-white/60 font-mono truncate max-w-[120px]">{a.agentId}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-white/40">{a.priority}</span>
+                    <span className={`tabular-nums ${utilPct > 80 ? 'text-red-400' : utilPct > 50 ? 'text-amber-400' : 'text-green-400'}`}>
+                      {utilPct}%
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/dashboard/SquadCoordinatorPanel.tsx
+++ b/src/renderer/components/dashboard/SquadCoordinatorPanel.tsx
@@ -1,0 +1,163 @@
+// SquadCoordinatorPanel.tsx — Squad overview, S2S communication, routing decisions, engagement gate
+import type { HubSquadData, HubSquadInfo, HubRoutingDecision, HubSquadHandoff } from '@shared/hub-types'
+import { RefreshCw, Users, ArrowRight } from 'lucide-react'
+
+interface Props {
+  data: HubSquadData | null
+  onRefresh: () => void
+}
+
+const dialColors = ['', 'text-gray-400', 'text-blue-400', 'text-green-400', 'text-amber-400', 'text-red-400']
+const dialLabels = ['', 'Observer', 'Advisor', 'Peer', 'Agent Team', 'Full Agent']
+
+const responseModeColors = {
+  DIRECT: 'text-green-400',
+  LIGHTWEIGHT: 'text-blue-400',
+  STANDARD: 'text-amber-400',
+  FULL: 'text-red-400',
+}
+
+const handoffTypeStyles = {
+  'request-response': { arrow: '→', style: 'border-blue-500/30' },
+  'scatter-gather': { arrow: '⇉', style: 'border-amber-500/30' },
+  'event-broadcast': { arrow: '⟶', style: 'border-white/10 border-dashed' },
+}
+
+function SquadCard({ squad }: { squad: HubSquadInfo }) {
+  return (
+    <div className="bg-white/5 rounded-lg p-3 border border-white/10" data-testid={`squad-${squad.squadId}`}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <Users size={12} className="text-white/40" />
+          <span className="text-white/80 text-xs font-medium">{squad.squadId}</span>
+        </div>
+        <span className="text-[10px] text-white/40">
+          Cap: L{squad.ceiling} <span className={dialColors[squad.ceiling]}>{dialLabels[squad.ceiling]}</span>
+        </span>
+      </div>
+      {/* Agent dial indicators */}
+      <div className="flex flex-wrap gap-1.5">
+        {squad.agents.map((a) => (
+          <div key={a.id} className="flex items-center gap-1 bg-white/5 rounded px-1.5 py-0.5" title={`${a.name} — L${a.engagementLevel} ${a.priority}`}>
+            <div className={`w-1.5 h-1.5 rounded-full ${
+              a.engagementLevel >= 4 ? 'bg-amber-500' :
+              a.engagementLevel >= 3 ? 'bg-green-500' :
+              a.engagementLevel >= 2 ? 'bg-blue-500' : 'bg-gray-500'
+            }`} />
+            <span className="text-[10px] text-white/60 font-mono">{a.id.slice(0, 12)}</span>
+            <span className="text-[9px] text-white/30">L{a.engagementLevel}</span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-1.5 text-[10px] text-white/30">
+        {squad.agents.length} agent{squad.agents.length !== 1 ? 's' : ''} • {squad.defaultLane}
+      </div>
+    </div>
+  )
+}
+
+function SquadHandoffRow({ handoff }: { handoff: HubSquadHandoff }) {
+  const style = handoffTypeStyles[handoff.type]
+  return (
+    <div className={`flex items-center gap-2 text-xs p-2 rounded border ${style.style}`}>
+      <span className="text-white/70 font-mono">{handoff.fromSquadId}</span>
+      <span className="text-white/30">{style.arrow}</span>
+      <span className="text-white/70 font-mono">{handoff.toSquadId}</span>
+      <span className="text-white/40 ml-auto text-[10px]">{handoff.type}</span>
+      <span className={`text-[10px] ${
+        handoff.status === 'active' ? 'text-green-400' :
+        handoff.status === 'pending' ? 'text-blue-400' :
+        handoff.status === 'failed' ? 'text-red-400' : 'text-white/40'
+      }`}>{handoff.status}</span>
+    </div>
+  )
+}
+
+function RoutingRow({ decision }: { decision: HubRoutingDecision }) {
+  const modeColor = responseModeColors[decision.responseMode] || 'text-white/40'
+  const age = `${Math.round((Date.now() - decision.timestamp) / 60000)}m`
+  return (
+    <div className="flex items-center gap-2 text-[11px] py-1 border-b border-white/5 last:border-0">
+      <span className="text-white/60 font-mono truncate max-w-[80px]">{decision.agentId}</span>
+      <ArrowRight size={10} className="text-white/20" />
+      <span className="text-white/50 truncate max-w-[80px]">{decision.toolName}</span>
+      <span className={modeColor}>{decision.responseMode}</span>
+      <span className={`text-[10px] ${
+        decision.zone === 'GREEN' ? 'text-green-400' :
+        decision.zone === 'AMBER' ? 'text-amber-400' : 'text-red-400'
+      }`}>{decision.zone}</span>
+      <span className={`ml-auto text-[10px] ${decision.allowed ? 'text-green-400' : 'text-red-400'}`}>
+        {decision.allowed ? '✓' : '✗'}
+      </span>
+      <span className="text-white/20 text-[10px]">{age}</span>
+    </div>
+  )
+}
+
+export function SquadCoordinatorPanel({ data, onRefresh }: Props) {
+  if (!data) {
+    return (
+      <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-squad-coordinator">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+            <Users size={14} /> Squad Coordinator
+          </div>
+          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        </div>
+        <div className="text-white/30 text-xs text-center py-6">No squad data</div>
+      </div>
+    )
+  }
+
+  const { squads, recentRouting, squadHandoffs } = data
+
+  return (
+    <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-squad-coordinator">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+          <Users size={14} /> Squad Coordinator
+        </div>
+        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+      </div>
+
+      {/* Squad cards */}
+      {squads.length > 0 && (
+        <div className="mb-4">
+          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Squads ({squads.length})</div>
+          <div className="grid grid-cols-2 gap-2">
+            {squads.map((s) => <SquadCard key={s.squadId} squad={s} />)}
+          </div>
+        </div>
+      )}
+
+      {/* Squad-to-Squad handoffs */}
+      {squadHandoffs.length > 0 && (
+        <div className="mb-4" data-testid="hub-squad-handoffs">
+          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Squad-to-Squad ({squadHandoffs.length})</div>
+          <div className="space-y-1.5 max-h-32 overflow-y-auto">
+            {squadHandoffs.map((h, i) => <SquadHandoffRow key={i} handoff={h} />)}
+          </div>
+        </div>
+      )}
+
+      {/* Recent routing decisions */}
+      {recentRouting.length > 0 && (
+        <div data-testid="hub-routing-decisions">
+          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Recent Routing ({recentRouting.length})</div>
+          <div className="max-h-36 overflow-y-auto">
+            {recentRouting.slice(0, 10).map((d, i) => <RoutingRow key={i} decision={d} />)}
+          </div>
+        </div>
+      )}
+
+      {/* Engagement legend */}
+      <div className="mt-3 flex items-center gap-3 text-[10px] text-white/30">
+        <span>Engagement:</span>
+        {[1, 2, 3, 4, 5].map((l) => (
+          <span key={l} className={dialColors[l]}>L{l} {dialLabels[l]}</span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/shared/hub-types.ts
+++ b/src/shared/hub-types.ts
@@ -124,7 +124,119 @@ export interface MonitorSnapshot {
   auditScope: 'enterprise' | 'org' | null
   auditLogError?: string
   ghawWorkflows: GhawWorkflowData | null
+  rateGovernor: HubRateGovernorData | null
+  handoffs: HubHandoffData | null
+  squadState: HubSquadData | null
   lastUpdated: Record<string, number>
+}
+
+// ============================================================================
+// Rate Governor Panel Types
+// ============================================================================
+
+export type TrafficLightZone = 'GREEN' | 'AMBER' | 'RED'
+export type CircuitBreakerState = 'CLOSED' | 'PRE_EMPTIVE_OPEN' | 'OPEN' | 'HALF_OPEN'
+export type CascadeMode = 'parallel' | 'sequential'
+
+export interface HubRateGovernorAgent {
+  agentId: string
+  priority: 'P0' | 'P1' | 'P2'
+  reserved: number
+  used: number
+  quotaType: 'github' | 'copilot'
+}
+
+export interface HubRateGovernorData {
+  state: {
+    trafficLight: TrafficLightZone
+    circuitState: CircuitBreakerState
+    circuitStateByQuota: { github: CircuitBreakerState; copilot: CircuitBreakerState }
+    cascadeMode: CascadeMode
+  }
+  github: { windowTotal: number; windowRemaining: number; donationPool: number }
+  copilot: { windowTotal: number; windowRemaining: number; donationPool: number }
+  agents: HubRateGovernorAgent[]
+}
+
+// ============================================================================
+// Handoff Flow Panel Types
+// ============================================================================
+
+export type HandoffStatus = 'pending' | 'active' | 'completed' | 'failed'
+export type HandoffPriority = 'low' | 'medium' | 'high' | 'critical'
+
+export interface HubHandoffEntry {
+  handoff_id: string
+  from_agent: string
+  to_agent: string
+  status: HandoffStatus
+  priority: HandoffPriority
+  task: string
+  sla_deadline?: string
+  created_at: string
+  completed_at?: string
+  failed_at?: string
+  failure_reason?: string
+}
+
+export interface HubHandoffStats {
+  total: number
+  active: number
+  completed: number
+  failed: number
+  avgCompletionMs: number
+  slaComplianceRate: number
+}
+
+export interface HubHandoffData {
+  active: HubHandoffEntry[]
+  recent: HubHandoffEntry[]
+  stats: HubHandoffStats
+}
+
+// ============================================================================
+// Squad Coordinator Panel Types
+// ============================================================================
+
+export interface HubSquadAgent {
+  id: string
+  name: string
+  engagementLevel: number
+  priority: 'P0' | 'P1' | 'P2'
+  skills: string[]
+}
+
+export interface HubSquadInfo {
+  squadId: string
+  ceiling: number
+  agents: HubSquadAgent[]
+  defaultLane: string
+}
+
+export interface HubRoutingDecision {
+  agentId: string
+  toolName: string
+  reason: string
+  responseMode: 'DIRECT' | 'LIGHTWEIGHT' | 'STANDARD' | 'FULL'
+  zone: TrafficLightZone
+  allowed: boolean
+  timestamp: number
+}
+
+export type SquadHandoffType = 'request-response' | 'scatter-gather' | 'event-broadcast'
+
+export interface HubSquadHandoff {
+  fromSquadId: string
+  toSquadId: string
+  type: SquadHandoffType
+  priority: 'P0' | 'P1' | 'P2'
+  status: HandoffStatus
+}
+
+export interface HubSquadData {
+  squads: HubSquadInfo[]
+  recentRouting: HubRoutingDecision[]
+  squadHandoffs: HubSquadHandoff[]
 }
 
 export interface RateLimitSample {


### PR DESCRIPTION
## Summary

Three new dashboard panels that visualize how Rate Governor, agent handoffs, and squad coordination work together in real-time:

- **RateGovernorPanel** — Traffic light zone (GREEN/AMBER/RED), quota pool bars, priority tier status, circuit breaker states, per-agent token allocations. Sits beside existing RateLimitPanel showing governance on top of raw API rates
- **HandoffFlowPanel** — Agent-to-agent work delegation flow: 4-state FSM badges, priority coloring, SLA tracking, completion stats, recent handoff timeline
- **SquadCoordinatorPanel** — Squad overview with engagement level indicators, squad-to-squad communication patterns (request-response/scatter-gather/event-broadcast), routing decisions with response modes, engagement gate legend

Extended `MonitorSnapshot` and `hub-types.ts` with `HubRateGovernorData`, `HubHandoffData`, and `HubSquadData` types. Panels render with "No data" placeholders until pollers are connected to live data sources.

### Dashboard Layout
```
RateLimitPanel  |  RateGovernorPanel [NEW]
HandoffFlowPanel (full width) [NEW]
SquadCoordinatorPanel (full width) [NEW]
TokenActivityPanel | ActionsMinutesPanel
...existing panels...
```

## Test plan

- [ ] `npm run dev` in Hub → open Hub dashboard → verify RateGovernorPanel renders with "No rate governor data" placeholder
- [ ] Verify HandoffFlowPanel renders with "No handoff data" placeholder  
- [ ] Verify SquadCoordinatorPanel renders with "No squad data" placeholder
- [ ] Verify existing panels (RateLimit, TokenActivity, etc.) still render correctly
- [ ] Verify no TypeScript compilation errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)