### PR TITLE
chore: CI workflows, staging build, and branching policy docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,28 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches-ignore:
+      - main
+      - staging
+    tags-ignore:
+      - v*
   pull_request:
-    branches: [main]
+    branches:
+      - staging
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build-packages:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -29,6 +44,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ghaw-staging-build.yml
+++ b/.github/workflows/ghaw-staging-build.yml
@@ -1,0 +1,86 @@
+name: "GH-AW: Staging Build"
+
+# Builds cross-platform Electron app packages from the staging branch.
+# Artifacts are uploaded for internal testing — NOT published to GitHub Releases.
+# Production releases use release.yml triggered by v* tags on main.
+#
+# Engagement Level: T3 (Peer Programmer) — builds artifacts, no deployment.
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+    inputs:
+      full_installers:
+        description: "Build full installers (slower) instead of unpacked dirs"
+        type: boolean
+        default: false
+
+concurrency:
+  group: staging-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-staging:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+            artifact_glob: "dist/*.exe"
+          - os: macos-latest
+            platform: mac
+            artifact_glob: "dist/*.dmg"
+          - os: ubuntu-latest
+            platform: linux
+            artifact_glob: "dist/*.AppImage"
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Electron app
+        run: |
+          npx electron-vite build
+          if [ "${{ inputs.full_installers }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
+            npx electron-builder --${{ matrix.platform == 'win' && 'win' || matrix.platform == 'mac' && 'mac' || 'linux' }}
+          else
+            npx electron-builder --${{ matrix.platform == 'win' && 'win' || matrix.platform == 'mac' && 'mac' || 'linux' }} --dir
+          fi
+        shell: bash
+        env:
+          # Do NOT set GH_TOKEN — prevents publishing to GitHub Releases
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Upload staging artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hub-staging-${{ matrix.platform }}-${{ github.sha }}
+          path: |
+            dist/*.exe
+            dist/*.dmg
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.snap
+            dist/win-unpacked/
+            dist/mac/
+            dist/linux-unpacked/
+          if-no-files-found: warn
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,43 @@ hub monitor    # Full Ink TUI (refreshes every 30s)
 hub status     # Single-line summary
 ```
 
+## Branching Policy (MANDATORY)
+
+This repo follows the org-standard promotion flow:
+
+```
+feature/* → staging → main → v* tag → GitHub Release
+```
+
+| Branch | Purpose | Protection |
+|--------|---------|------------|
+| `main` | Production-ready code; tags trigger releases | PRs from staging only, 1 review required |
+| `staging` | Integration testing; pushes trigger cross-platform builds | PRs from feature/* branches, 1 review required |
+| `feature/*` | Development work | No restrictions |
+
+### Accepted branch prefixes for PRs to staging
+
+`feature/`, `feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`
+
+### Release process
+
+1. Feature branch → PR to staging (CI runs, review required)
+2. Push to staging triggers cross-platform staging builds (artifacts)
+3. Test staging artifacts internally
+4. staging → PR to main (policy guard enforces this)
+5. After merge, staging-refresh recreates staging from main
+6. Tag main with `vX.Y.Z` to trigger release to GitHub Releases
+
+### Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | Push to feature branches, PRs to staging/main | Lint + build validation |
+| `ghaw-branch-policy-guard.yml` | PRs to staging/main | Enforces branch flow |
+| `ghaw-staging-build.yml` | Push to staging | Cross-platform installer builds (artifacts) |
+| `ghaw-staging-refresh.yml` | staging→main PR merged | Resets staging to match main |
+| `release.yml` | `v*` tags | Cross-platform build + publish to GitHub Releases |
+
 ## Build & Run
 
 ```bash


### PR DESCRIPTION
## Summary

- **`ci.yml`**: Updated triggers — runs on feature branch pushes + PRs to staging/main (no longer on push to main/staging directly). Added concurrency group and workflow_dispatch.
- **`ghaw-staging-build.yml`**: New cross-platform Electron build workflow triggered on push to staging. Builds for Windows/macOS/Linux, uploads artifacts with 7-day retention for internal testing. Optional full installer build via manual dispatch.
- **`AGENTS.md`**: Added Branching Policy section documenting the `feature/* → staging → main → v* tag` flow and all workflow triggers.

### Already bootstrapped to main (separate commit)
- `ghaw-branch-policy-guard.yml` — enforces branching model
- `ghaw-staging-refresh.yml` — recreates staging after promotion

### Complete workflow set after merge

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `ci.yml` | Feature pushes, PRs to staging/main | Lint + build validation |
| `ghaw-branch-policy-guard.yml` | PRs to staging/main | Branch flow enforcement |
| `ghaw-staging-build.yml` | Push to staging | Cross-platform artifact builds |
| `ghaw-staging-refresh.yml` | staging→main merge | Reset staging from main |
| `release.yml` | `v*` tags | Cross-platform publish to GitHub Releases |

## Test plan
- [ ] CI runs on this PR (targeting staging)
- [ ] After merge to staging, `ghaw-staging-build.yml` triggers cross-platform builds
- [ ] Branch policy guard blocks PRs to main from non-staging branches
- [ ] Staging refresh runs after eventual staging→main promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)