### PR TITLE
feat: add Recording Studio cross-repo workflow_call test

### DIFF
--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -16,6 +16,8 @@ on:
           - all
         default: pipeline-validate
 
+permissions:
+  contents: read
 jobs:
   test-pipeline-validate:
     name: "Test: Pipeline Validate"

--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -2,6 +2,14 @@ name: "Recording Studio: Cross-Repo Test (Hub)"
 
 # Tests that RecordingStudio workflow_call triggers work from AgentCraftworks-Hub.
 # Validates pipeline validation and SkillUp script generation workflows.
+#
+# SECURITY: The reusable workflows below reference @main, a mutable ref. Until
+# RecordingStudio publishes an immutable tag or agreed-upon SHA, a manual-approval
+# gate is enforced via the `recording-studio-external` GitHub environment.
+# To activate the gate: Settings → Environments → recording-studio-external →
+# add required reviewers. To complete the SHA pin, replace @main with the output of:
+#   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
+# and append `# main` as a trailing comment on each `uses:` line.
 
 on:
   workflow_dispatch:
@@ -18,15 +26,23 @@ on:
 
 permissions:
   contents: read
+
 jobs:
+  gate-external-call:
+    name: "Gate: Approve external workflow_call"
+    runs-on: ubuntu-latest
+    # Requires manual approval — configure required reviewers in
+    # Settings → Environments → recording-studio-external
+    environment: recording-studio-external
+    steps:
+      - run: echo "External workflow_call approved."
+
   test-pipeline-validate:
     name: "Test: Pipeline Validate"
+    needs: gate-external-call
     if: inputs.test_scope == 'pipeline-validate' || inputs.test_scope == 'all'
-    # TODO(security): pin to an immutable SHA instead of @main to prevent supply-chain drift.
-    # Obtain the current SHA with:
-    #   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
-    # Then replace @main with @<SHA> and add a trailing comment: # main
-    uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@main
+    # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@main # main
     with:
       slug: "all"
       run_voice: false
@@ -34,12 +50,10 @@ jobs:
 
   test-skillup-script:
     name: "Test: SkillUp Script Generation"
+    needs: gate-external-call
     if: inputs.test_scope == 'skillup-script' || inputs.test_scope == 'all'
-    # TODO(security): pin to an immutable SHA instead of @main to prevent supply-chain drift.
-    # Obtain the current SHA with:
-    #   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
-    # Then replace @main with @<SHA> and add a trailing comment: # main
-    uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@main
+    # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@main # main
     with:
       topic: "AgentCraftworks Hub MCP Server Architecture"
       format: "video"

--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -1,0 +1,39 @@
+name: "Recording Studio: Cross-Repo Test (Hub)"
+
+# Tests that RecordingStudio workflow_call triggers work from AgentCraftworks-Hub.
+# Validates pipeline validation and SkillUp script generation workflows.
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_scope:
+        description: "Which test to run"
+        required: true
+        type: choice
+        options:
+          - pipeline-validate
+          - skillup-script
+          - all
+        default: pipeline-validate
+
+jobs:
+  test-pipeline-validate:
+    name: "Test: Pipeline Validate"
+    if: inputs.test_scope == 'pipeline-validate' || inputs.test_scope == 'all'
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@main
+    with:
+      slug: "all"
+      run_voice: false
+      voice: "stock"
+
+  test-skillup-script:
+    name: "Test: SkillUp Script Generation"
+    if: inputs.test_scope == 'skillup-script' || inputs.test_scope == 'all'
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@main
+    with:
+      topic: "AgentCraftworks Hub MCP Server Architecture"
+      format: "video"
+      skill_level: "intermediate"
+      tech_stack: "TypeScript, Electron, MCP"
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -22,6 +22,10 @@ jobs:
   test-pipeline-validate:
     name: "Test: Pipeline Validate"
     if: inputs.test_scope == 'pipeline-validate' || inputs.test_scope == 'all'
+    # TODO(security): pin to an immutable SHA instead of @main to prevent supply-chain drift.
+    # Obtain the current SHA with:
+    #   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
+    # Then replace @main with @<SHA> and add a trailing comment: # main
     uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@main
     with:
       slug: "all"
@@ -31,6 +35,10 @@ jobs:
   test-skillup-script:
     name: "Test: SkillUp Script Generation"
     if: inputs.test_scope == 'skillup-script' || inputs.test_scope == 'all'
+    # TODO(security): pin to an immutable SHA instead of @main to prevent supply-chain drift.
+    # Obtain the current SHA with:
+    #   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
+    # Then replace @main with @<SHA> and add a trailing comment: # main
     uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@main
     with:
       topic: "AgentCraftworks Hub MCP Server Architecture"


### PR DESCRIPTION
Adds a manually triggered GitHub Actions workflow to validate cross-repo `workflow_call` invocations into `AgentCraftworks/RecordingStudio`, ensuring the Hub can execute the reusable workflows for pipeline validation and SkillUp script generation.

## Changes

- Introduces `.github/workflows/recording-studio-test.yml` with `workflow_dispatch` + `test_scope` input
- Adds `permissions: contents: read` top-level block
- Adds a `gate-external-call` job backed by the `recording-studio-external` GitHub environment; both test jobs declare `needs: gate-external-call`, enforcing manual approval before any external `workflow_call` fires (including before `OPENAI_API_KEY` is forwarded)
- Both `uses:` lines carry a `# main` trailing comment to document branch provenance
- File header documents the SHA-pinning path: once RecordingStudio publishes a stable ref, replace `@main` with the SHA from `git ls-remote` and remove the gate job

## Security

The reusable workflows reference `@main`, a mutable ref. Until a SHA/tag pin is possible (RecordingStudio is a private repo), the `recording-studio-external` environment gate prevents any external call from running without explicit human approval. To activate the gate, configure required reviewers under **Settings → Environments → recording-studio-external**.

## Test plan

- Merge this PR, then configure the `recording-studio-external` environment with required reviewers
- Run workflow manually via Actions tab with `test_scope: pipeline-validate` and approve the gate
- Run workflow with `test_scope: all` to test both invocations