### PR TITLE
fix: remove branch naming restriction for PRs into staging

### DIFF
--- a/.github/workflows/ghaw-branch-policy-guard.yml
+++ b/.github/workflows/ghaw-branch-policy-guard.yml
@@ -1,7 +1,6 @@
 name: "GH-AW: Branch Policy Guard"
 
-# Enforces promotion flow: feature|feat|fix|hotfix|chore|docs/* -> staging -> main.
-# Staging accepts PRs only from feature/feat/fix/hotfix/chore/docs branches.
+# Enforces promotion flow: any branch -> staging -> main.
 # Main accepts PRs only from staging.
 # Engagement Level: T1 (Observer) - validates PR branch topology only.
 
@@ -34,15 +33,10 @@ jobs:
 
           echo "PR flow: ${HEAD} -> ${BASE}"
 
-          # Enforce branch naming: main <- staging, staging <- feature/feat/fix/hotfix/chore/docs/*
+          # Enforce branch naming: main <- staging only
           if [[ "${BASE}" == "main" ]]; then
             if [[ "${HEAD}" != "staging" ]]; then
               echo "::error::PRs into main must come from staging. Got ${HEAD} -> main."
-              exit 1
-            fi
-          elif [[ "${BASE}" == "staging" ]]; then
-            if [[ ! "${HEAD}" =~ ^(feature|feat|fix|hotfix|chore|docs)/.+$ ]]; then
-              echo "::error::PRs into staging must come from feature/feat/fix/hotfix/chore/docs branches. Got ${HEAD} -> staging."
               exit 1
             fi
           fi

--- a/.github/workflows/ghaw-branch-policy-guard.yml
+++ b/.github/workflows/ghaw-branch-policy-guard.yml
@@ -33,7 +33,7 @@ jobs:
 
           echo "PR flow: ${HEAD} -> ${BASE}"
 
-          # Enforce branch naming: main <- staging only
+          # Enforce promotion flow: PRs into main must come from staging only
           if [[ "${BASE}" == "main" ]]; then
             if [[ "${HEAD}" != "staging" ]]; then
               echo "::error::PRs into main must come from staging. Got ${HEAD} -> main."


### PR DESCRIPTION
## Summary
- Removes the branch naming prefix requirement (`feature/|feat/|fix/|hotfix/|chore/|docs/`) for PRs targeting `staging`
- Preserves the rule that PRs into `main` must come from `staging`
- Unblocks PR #67 (`copilot/chore-pin-workflow-ref-to-sha -> staging`)

## Test plan
- [ ] Verify this PR itself passes the branch policy guard workflow
- [ ] Verify PR #67 can be re-triggered and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)