### PR TITLE
fix: pin RecordingStudio workflow refs to immutable SHA (#66)

### DIFF
--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -41,7 +41,6 @@ jobs:
     name: "Test: Pipeline Validate"
     needs: gate-external-call
     if: inputs.test_scope == 'pipeline-validate' || inputs.test_scope == 'all'
-    # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
     uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@b91943ffa818c0e06f087fb08afd9e18e496bd87 # main
     with:
       slug: "all"
@@ -52,7 +51,6 @@ jobs:
     name: "Test: SkillUp Script Generation"
     needs: gate-external-call
     if: inputs.test_scope == 'skillup-script' || inputs.test_scope == 'all'
-    # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
     uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@b91943ffa818c0e06f087fb08afd9e18e496bd87 # main
     with:
       topic: "AgentCraftworks Hub MCP Server Architecture"

--- a/.github/workflows/recording-studio-test.yml
+++ b/.github/workflows/recording-studio-test.yml
@@ -3,13 +3,13 @@ name: "Recording Studio: Cross-Repo Test (Hub)"
 # Tests that RecordingStudio workflow_call triggers work from AgentCraftworks-Hub.
 # Validates pipeline validation and SkillUp script generation workflows.
 #
-# SECURITY: The reusable workflows below reference @main, a mutable ref. Until
-# RecordingStudio publishes an immutable tag or agreed-upon SHA, a manual-approval
-# gate is enforced via the `recording-studio-external` GitHub environment.
+# SECURITY: Reusable workflows below are pinned to an immutable commit SHA from
+# RecordingStudio's main branch (pinned 2026-04-02). A manual-approval gate is
+# also enforced via the `recording-studio-external` GitHub environment.
 # To activate the gate: Settings → Environments → recording-studio-external →
-# add required reviewers. To complete the SHA pin, replace @main with the output of:
+# add required reviewers. To update the pinned SHA, run:
 #   git ls-remote https://github.com/AgentCraftworks/RecordingStudio.git refs/heads/main
-# and append `# main` as a trailing comment on each `uses:` line.
+# and replace the SHA on each `uses:` line, keeping the `# main` trailing comment.
 
 on:
   workflow_dispatch:
@@ -42,7 +42,7 @@ jobs:
     needs: gate-external-call
     if: inputs.test_scope == 'pipeline-validate' || inputs.test_scope == 'all'
     # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
-    uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@main # main
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/recording-studio-pipeline.yml@b91943ffa818c0e06f087fb08afd9e18e496bd87 # main
     with:
       slug: "all"
       run_voice: false
@@ -53,7 +53,7 @@ jobs:
     needs: gate-external-call
     if: inputs.test_scope == 'skillup-script' || inputs.test_scope == 'all'
     # Replace @main with a pinned SHA once RecordingStudio publishes a stable ref.
-    uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@main # main
+    uses: AgentCraftworks/RecordingStudio/.github/workflows/skillup.yml@b91943ffa818c0e06f087fb08afd9e18e496bd87 # main
     with:
       topic: "AgentCraftworks Hub MCP Server Architecture"
       format: "video"


### PR DESCRIPTION
- [x] Remove outdated inline job comments ("Replace @main with a pinned SHA...") from `recording-studio-test.yml` lines 44 and 55 — the SHA is already pinned; guidance lives in the SECURITY header at the top of the file