### PR TITLE
feat: FluentUI migration — HubDashboard + dashboard panels (WIP)

### DIFF
--- a/src/renderer/components/dashboard/ActionsMinutesPanel.tsx
+++ b/src/renderer/components/dashboard/ActionsMinutesPanel.tsx
@@ -1,22 +1,23 @@
 // ActionsMinutesPanel.tsx — GitHub Actions minutes usage and estimated total cost
 import type { BillingData } from '@shared/hub-types'
 import { Timer, AlertTriangle } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface Props {
   data: BillingData | null
 }
 
 const OS_MULTIPLIERS = [
-  { label: 'Ubuntu (1×)', key: 'ubuntu' as const, color: 'bg-green-500' },
-  { label: 'Windows (2×)', key: 'windows' as const, color: 'bg-blue-500' },
-  { label: 'macOS (10×)', key: 'macos' as const, color: 'bg-orange-500' },
+  { label: 'Ubuntu (1×)', key: 'ubuntu' as const, color: '#22c55e' },
+  { label: 'Windows (2×)', key: 'windows' as const, color: '#3b82f6' },
+  { label: 'macOS (10×)', key: 'macos' as const, color: '#f97316' },
 ]
 
 export function ActionsMinutesPanel({ data }: Props) {
   if (!data) {
     return (
       <Panel>
-        <div className="text-white/30 text-xs flex items-center justify-center h-16">Loading…</div>
+        <div style={{ ...ps.loadingState, height: '64px' }}>Loading…</div>
       </Panel>
     )
   }
@@ -24,10 +25,10 @@ export function ActionsMinutesPanel({ data }: Props) {
   if (data.error) {
     return (
       <Panel>
-        <div className="flex flex-col items-center justify-center h-24 gap-2 text-white/30">
+        <div style={{ ...ps.errorState, height: '96px' }}>
           <AlertTriangle size={18} />
-          <p className="text-xs text-center">
-            Requires <span className="text-white/60">read:enterprise</span> scope
+          <p style={ps.errorDetail}>
+            Requires <span style={ps.scopeHighlight}>read:enterprise</span> scope
           </p>
         </div>
       </Panel>
@@ -35,39 +36,37 @@ export function ActionsMinutesPanel({ data }: Props) {
   }
 
   const m = data.actionsMinutes!
-  const pct = m.includedMinutes > 0
-    ? Math.min(100, Math.round((m.totalMinutesUsed / m.includedMinutes) * 100))
-    : 0
-  const barColor = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : 'bg-green-500'
+  const pct = m.includedMinutes > 0 ? Math.min(100, Math.round((m.totalMinutesUsed / m.includedMinutes) * 100)) : 0
+  const barColor = pct >= 90 ? '#ef4444' : pct >= 70 ? '#f59e0b' : '#22c55e'
   const breakdown = m.minutesUsedBreakdown
   const total = m.totalMinutesUsed || 1
 
   return (
     <Panel>
       {/* Main progress */}
-      <div className="mb-4">
-        <div className="flex justify-between text-xs mb-1.5">
-          <span className="text-white/60">{m.totalMinutesUsed.toLocaleString()} min used</span>
-          <span className="text-white/40">{m.includedMinutes.toLocaleString()} included</span>
+      <div style={{ marginBottom: '16px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginBottom: '6px' }}>
+          <span style={{ color: 'rgba(255,255,255,0.6)' }}>{m.totalMinutesUsed.toLocaleString()} min used</span>
+          <span style={ps.textMuted}>{m.includedMinutes.toLocaleString()} included</span>
         </div>
-        <div className="h-2 bg-white/10 rounded-full overflow-hidden">
-          <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+        <div style={ps.barTrack}>
+          <div style={{ height: '100%', borderRadius: '999px', transition: 'width 300ms', backgroundColor: barColor, width: `${pct}%` }} />
         </div>
-        <div className="text-[10px] text-white/30 mt-1">{pct}% of included minutes used</div>
+        <div style={{ ...ps.finePrint, marginTop: '4px' }}>{pct}% of included minutes used</div>
       </div>
 
       {/* OS breakdown bars */}
-      <div className="space-y-1.5 mb-4">
+      <div style={{ ...ps.stackSm, gap: '6px', marginBottom: '16px' }}>
         {OS_MULTIPLIERS.map(({ label, key, color }) => {
           const mins = breakdown[key] ?? 0
           const barW = Math.round((mins / total) * 100)
           return (
-            <div key={key} className="flex items-center gap-2 text-[11px]">
-              <span className="text-white/40 w-28 flex-shrink-0">{label}</span>
-              <div className="flex-1 h-1 bg-white/10 rounded-full overflow-hidden">
-                <div className={`h-full rounded-full ${color}`} style={{ width: `${barW}%` }} />
+            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '11px' }}>
+              <span style={{ ...ps.textMuted, width: '112px', flexShrink: 0 }}>{label}</span>
+              <div style={{ ...ps.thinBarTrack, flex: 1 }}>
+                <div style={{ height: '100%', borderRadius: '999px', backgroundColor: color, width: `${barW}%` }} />
               </div>
-              <span className="text-white/50 tabular-nums w-14 text-right">
+              <span style={{ color: 'rgba(255,255,255,0.5)', fontVariantNumeric: 'tabular-nums', width: '56px', textAlign: 'right' }}>
                 {mins.toLocaleString()} min
               </span>
             </div>
@@ -77,15 +76,15 @@ export function ActionsMinutesPanel({ data }: Props) {
 
       {/* Overage */}
       {m.totalPaidMinutesUsed > 0 && (
-        <div className="border-t border-white/10 pt-3 flex justify-between text-xs">
-          <span className="text-amber-400">Overage minutes</span>
-          <span className="text-amber-400 font-mono">{m.totalPaidMinutesUsed.toLocaleString()}</span>
+        <div style={{ ...ps.divider, display: 'flex', justifyContent: 'space-between', fontSize: '12px' }}>
+          <span style={{ color: '#fbbf24' }}>Overage minutes</span>
+          <span style={{ color: '#fbbf24', fontFamily: 'monospace' }}>{m.totalPaidMinutesUsed.toLocaleString()}</span>
         </div>
       )}
       {m.estimatedCostUsd > 0 && (
-        <div className="flex justify-between text-xs mt-1">
-          <span className="text-white/40">Est. total cost</span>
-          <span className="text-amber-400 font-mono">${m.estimatedCostUsd.toFixed(2)}</span>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginTop: '4px' }}>
+          <span style={ps.textMuted}>Est. total cost</span>
+          <span style={{ color: '#fbbf24', fontFamily: 'monospace' }}>${m.estimatedCostUsd.toFixed(2)}</span>
         </div>
       )}
     </Panel>
@@ -94,8 +93,8 @@ export function ActionsMinutesPanel({ data }: Props) {
 
 function Panel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-      <div className="flex items-center gap-2 text-sm font-semibold text-white/80 mb-3">
+    <div style={ps.panelCard}>
+      <div style={ps.panelHeader}>
         <Timer size={14} />
         Actions Minutes
       </div>

--- a/src/renderer/components/dashboard/BillingPanel.tsx
+++ b/src/renderer/components/dashboard/BillingPanel.tsx
@@ -1,56 +1,47 @@
 // BillingPanel.tsx — Estimated month-to-date GitHub billing summary
 import type { BillingData, CopilotUsageData } from '@shared/hub-types'
 import { DollarSign, AlertTriangle } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface Props {
   billing: BillingData | null
   copilot: CopilotUsageData | null
 }
 
-const COPILOT_SEAT_PRICE_USD = 19 // per seat/month (Business tier)
+const COPILOT_SEAT_PRICE_USD = 19
 
 export function BillingPanel({ billing, copilot }: Props) {
   const actionsCost = billing?.actionsMinutes?.estimatedCostUsd ?? 0
   const activeUsers = copilot?.totalActiveUsers ?? 0
   const copilotCost = activeUsers * COPILOT_SEAT_PRICE_USD
   const total = actionsCost + copilotCost
-
   const hasError = billing?.error || copilot?.error
 
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-      <div className="flex items-center gap-2 text-sm font-semibold text-white/80 mb-3">
+    <div style={ps.panelCard}>
+      <div style={ps.panelHeader}>
         <DollarSign size={14} />
         Billing Estimate
-        <span className="ml-auto text-[10px] text-white/30 font-normal">month-to-date</span>
+        <span style={ps.headerSubtext}>month-to-date</span>
       </div>
 
       {hasError && (
-        <div className="flex items-center gap-2 text-amber-400/70 text-xs mb-3">
+        <div style={{ ...ps.flexRow, color: 'rgba(251,191,36,0.7)', fontSize: '12px', marginBottom: '12px' }}>
           <AlertTriangle size={12} />
           Partial data — some scopes unavailable
         </div>
       )}
 
-      <div className="space-y-2 text-sm">
-        <LineItem
-          label="Copilot seats"
-          sublabel={activeUsers > 0 ? `${activeUsers} active × $${COPILOT_SEAT_PRICE_USD}/mo` : undefined}
-          value={copilotCost}
-          color="text-blue-400"
-        />
-        <LineItem
-          label="Actions cost (MTD)"
-          value={actionsCost}
-          color="text-amber-400"
-        />
-        <div className="border-t border-white/10 pt-2 flex justify-between font-semibold">
-          <span className="text-white/70">Est. Total</span>
-          <span className="text-white font-mono">${total.toFixed(2)}</span>
+      <div style={ps.stackSm}>
+        <LineItem label="Copilot seats" sublabel={activeUsers > 0 ? `${activeUsers} active × $${COPILOT_SEAT_PRICE_USD}/mo` : undefined} value={copilotCost} color="#60a5fa" />
+        <LineItem label="Actions cost (MTD)" value={actionsCost} color="#fbbf24" />
+        <div style={{ ...ps.divider, display: 'flex', justifyContent: 'space-between', fontWeight: 600 }}>
+          <span style={{ color: 'rgba(255,255,255,0.7)' }}>Est. Total</span>
+          <span style={{ color: '#fff', fontFamily: 'monospace' }}>${total.toFixed(2)}</span>
         </div>
       </div>
 
-      <p className="text-[10px] text-white/20 mt-3 leading-relaxed">
+      <p style={{ ...ps.finePrint, marginTop: '12px' }}>
         Copilot cost estimated from active seats. Actions cost is the reported month-to-date total from the billing API.
         Does not include storage, packages, or enterprise licensing.
       </p>
@@ -58,24 +49,14 @@ export function BillingPanel({ billing, copilot }: Props) {
   )
 }
 
-function LineItem({
-  label,
-  sublabel,
-  value,
-  color,
-}: {
-  label: string
-  sublabel?: string
-  value: number
-  color: string
-}) {
+function LineItem({ label, sublabel, value, color }: { label: string; sublabel?: string; value: number; color: string }) {
   return (
-    <div className="flex items-start justify-between gap-2">
+    <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '8px', fontSize: '13px' }}>
       <div>
-        <div className="text-white/60">{label}</div>
-        {sublabel && <div className="text-[10px] text-white/30">{sublabel}</div>}
+        <div style={{ color: 'rgba(255,255,255,0.6)' }}>{label}</div>
+        {sublabel && <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.3)' }}>{sublabel}</div>}
       </div>
-      <span className={`font-mono tabular-nums ${color}`}>${value.toFixed(2)}</span>
+      <span style={{ fontFamily: 'monospace', fontVariantNumeric: 'tabular-nums', color }}>${value.toFixed(2)}</span>
     </div>
   )
 }

--- a/src/renderer/components/dashboard/CopilotUsagePanel.tsx
+++ b/src/renderer/components/dashboard/CopilotUsagePanel.tsx
@@ -2,6 +2,7 @@
 import type { CopilotUsageData } from '@shared/hub-types'
 import { Bot, AlertTriangle } from 'lucide-react'
 import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import * as ps from './panel-styles'
 
 interface Props {
   data: CopilotUsageData | null
@@ -26,7 +27,7 @@ export function CopilotUsagePanel({ data }: Props) {
   if (!data) {
     return (
       <Panel>
-        <div className="text-white/30 text-xs flex items-center justify-center h-16">Loading…</div>
+        <div style={{ ...ps.loadingState, height: '64px' }}>Loading…</div>
       </Panel>
     )
   }
@@ -34,10 +35,10 @@ export function CopilotUsagePanel({ data }: Props) {
   if (data.error) {
     return (
       <Panel>
-        <div className="flex flex-col items-center justify-center h-24 gap-2 text-white/30">
+        <div style={{ ...ps.errorState, height: '96px' }}>
           <AlertTriangle size={18} />
-          <p className="text-xs text-center">
-            Requires <span className="text-white/60">manage_billing:copilot</span> scope
+          <p style={ps.errorDetail}>
+            Requires <span style={ps.scopeHighlight}>manage_billing:copilot</span> scope
           </p>
         </div>
       </Panel>
@@ -55,7 +56,7 @@ export function CopilotUsagePanel({ data }: Props) {
   return (
     <Panel>
       {/* Stats row */}
-      <div className="grid grid-cols-2 gap-3 mb-4">
+      <div style={{ ...ps.grid2, marginBottom: '16px' }}>
         {seats ? (
           <>
             <Stat label="Total Seats" value={seats.total} />
@@ -70,22 +71,19 @@ export function CopilotUsagePanel({ data }: Props) {
           </>
         )}
         <Stat label="Premium Requests" value={data.premiumRequestsUsed} highlight />
-        <Stat
-          label="Plan"
-          value={data.planType ?? '—'}
-        />
+        <Stat label="Plan" value={data.planType ?? '—'} />
       </div>
 
       {/* Model breakdown chart */}
       {chartData.length > 0 && (
         <div>
-          <div className="text-[10px] text-white/30 mb-2">Suggestions by model (latest day)</div>
+          <div style={{ ...ps.finePrint, marginBottom: '8px' }}>Suggestions by model (latest day)</div>
           <ResponsiveContainer width="100%" height={80}>
             <BarChart data={chartData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
               <XAxis dataKey="name" tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.4)' }} axisLine={false} tickLine={false} />
               <Tooltip
                 contentStyle={{ background: '#1f2937', border: 'none', borderRadius: 4, fontSize: 11 }}
-                formatter={(v: number, _: string, p: { payload: { fullName: string } }) => [v.toLocaleString(), p.payload.fullName]}
+                formatter={(v: number, _: string, p: { payload?: { fullName?: string } }) => [v.toLocaleString(), p.payload?.fullName ?? '']}
               />
               <Bar dataKey="suggestions" radius={[2, 2, 0, 0]}>
                 {chartData.map((entry) => (
@@ -102,9 +100,9 @@ export function CopilotUsagePanel({ data }: Props) {
 
 function Stat({ label, value, highlight }: { label: string; value: number | string; highlight?: boolean }) {
   return (
-    <div className="bg-white/5 rounded-lg px-3 py-2">
-      <div className="text-[10px] text-white/40">{label}</div>
-      <div className={`text-lg font-bold tabular-nums ${highlight ? 'text-blue-400' : 'text-white/80'}`}>
+    <div style={ps.statBox}>
+      <div style={ps.statLabel}>{label}</div>
+      <div style={highlight ? ps.statValueHighlight : ps.statValue}>
         {typeof value === 'number' ? value.toLocaleString() : value}
       </div>
     </div>
@@ -113,8 +111,8 @@ function Stat({ label, value, highlight }: { label: string; value: number | stri
 
 function Panel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-      <div className="flex items-center gap-2 text-sm font-semibold text-white/80 mb-3">
+    <div style={ps.panelCard}>
+      <div style={ps.panelHeader}>
         <Bot size={14} />
         Copilot Usage
       </div>

--- a/src/renderer/components/dashboard/HandoffFlowPanel.tsx
+++ b/src/renderer/components/dashboard/HandoffFlowPanel.tsx
@@ -1,6 +1,7 @@
 // HandoffFlowPanel.tsx — Agent-to-agent handoff flow visualization
 import type { HubHandoffData, HubHandoffEntry, HandoffStatus, HandoffPriority } from '@shared/hub-types'
 import { RefreshCw, ArrowRight, GitPullRequest } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface Props {
   data: HubHandoffData | null
@@ -8,46 +9,38 @@ interface Props {
 }
 
 const statusColors: Record<HandoffStatus, { bg: string; text: string; label: string }> = {
-  pending: { bg: 'bg-blue-500/20', text: 'text-blue-400', label: 'Pending' },
-  active: { bg: 'bg-green-500/20', text: 'text-green-400', label: 'Active' },
-  completed: { bg: 'bg-white/10', text: 'text-white/60', label: 'Done' },
-  failed: { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Failed' },
+  pending: { bg: 'rgba(59,130,246,0.2)', text: '#60a5fa', label: 'Pending' },
+  active: { bg: 'rgba(34,197,94,0.2)', text: '#4ade80', label: 'Active' },
+  completed: { bg: 'rgba(255,255,255,0.1)', text: 'rgba(255,255,255,0.6)', label: 'Done' },
+  failed: { bg: 'rgba(239,68,68,0.2)', text: '#f87171', label: 'Failed' },
 }
 
 const priorityColors: Record<HandoffPriority, string> = {
-  critical: 'text-red-400',
-  high: 'text-amber-400',
-  medium: 'text-blue-400',
-  low: 'text-white/40',
+  critical: '#f87171',
+  high: '#fbbf24',
+  medium: '#60a5fa',
+  low: 'rgba(255,255,255,0.4)',
 }
 
 function HandoffCard({ handoff }: { handoff: HubHandoffEntry }) {
   const status = statusColors[handoff.status]
   const priColor = priorityColors[handoff.priority]
-  const age = handoff.created_at
-    ? `${Math.round((Date.now() - new Date(handoff.created_at).getTime()) / 60000)}m ago`
-    : ''
+  const age = handoff.created_at ? `${Math.round((Date.now() - new Date(handoff.created_at).getTime()) / 60000)}m ago` : ''
 
   return (
-    <div className={`rounded-lg p-3 border border-white/5 ${status.bg}`} data-testid={`handoff-${handoff.handoff_id}`}>
-      {/* Agent flow */}
-      <div className="flex items-center gap-2 mb-1.5">
-        <span className="text-white/80 text-xs font-mono truncate max-w-[100px]">{handoff.from_agent}</span>
-        <ArrowRight size={12} className="text-white/30 flex-shrink-0" />
-        <span className="text-white/80 text-xs font-mono truncate max-w-[100px]">{handoff.to_agent}</span>
-        <span className={`ml-auto text-[10px] font-medium ${status.text}`}>{status.label}</span>
+    <div style={{ borderRadius: '8px', padding: '12px', border: '1px solid rgba(255,255,255,0.05)', backgroundColor: status.bg }} data-testid={`handoff-${handoff.handoff_id}`}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+        <span style={{ ...ps.textPrimary, fontSize: '12px', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100px' }}>{handoff.from_agent}</span>
+        <ArrowRight size={12} style={{ color: 'rgba(255,255,255,0.3)', flexShrink: 0 }} />
+        <span style={{ ...ps.textPrimary, fontSize: '12px', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100px' }}>{handoff.to_agent}</span>
+        <span style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 500, color: status.text }}>{status.label}</span>
       </div>
-      {/* Task + metadata */}
-      <div className="text-[11px] text-white/50 truncate mb-1">{handoff.task}</div>
-      <div className="flex items-center gap-2 text-[10px]">
-        <span className={priColor}>{handoff.priority}</span>
-        <span className="text-white/30">{age}</span>
-        {handoff.sla_deadline && (
-          <span className="text-amber-400/70">SLA: {new Date(handoff.sla_deadline).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-        )}
-        {handoff.failure_reason && (
-          <span className="text-red-400 truncate max-w-[120px]">{handoff.failure_reason}</span>
-        )}
+      <div style={{ fontSize: '11px', color: 'rgba(255,255,255,0.5)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: '4px' }}>{handoff.task}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '10px' }}>
+        <span style={{ color: priColor }}>{handoff.priority}</span>
+        <span style={ps.textFaint}>{age}</span>
+        {handoff.sla_deadline && <span style={{ color: 'rgba(251,191,36,0.7)' }}>SLA: {new Date(handoff.sla_deadline).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>}
+        {handoff.failure_reason && <span style={{ color: '#f87171', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '120px' }}>{handoff.failure_reason}</span>}
       </div>
     </div>
   )
@@ -55,9 +48,9 @@ function HandoffCard({ handoff }: { handoff: HubHandoffEntry }) {
 
 function StatCard({ label, value, color }: { label: string; value: string | number; color: string }) {
   return (
-    <div className="text-center">
-      <div className={`text-lg font-bold tabular-nums ${color}`}>{value}</div>
-      <div className="text-[10px] text-white/40">{label}</div>
+    <div style={{ textAlign: 'center' }}>
+      <div style={{ fontSize: '18px', fontWeight: 700, fontVariantNumeric: 'tabular-nums', color }}>{value}</div>
+      <div style={ps.statLabel}>{label}</div>
     </div>
   )
 }
@@ -65,14 +58,14 @@ function StatCard({ label, value, color }: { label: string; value: string | numb
 export function HandoffFlowPanel({ data, onRefresh }: Props) {
   if (!data) {
     return (
-      <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-handoff-flow">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+      <div style={ps.panelCard} data-testid="hub-handoff-flow">
+        <div style={ps.panelHeaderSpaced}>
+          <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
             <GitPullRequest size={14} /> Agent Handoffs
           </div>
-          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+          <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
         </div>
-        <div className="text-white/30 text-xs text-center py-6">No handoff data</div>
+        <div style={{ ...ps.loadingState, paddingTop: '24px', paddingBottom: '24px' }}>No handoff data</div>
       </div>
     )
   }
@@ -81,55 +74,44 @@ export function HandoffFlowPanel({ data, onRefresh }: Props) {
   const avgTime = stats.avgCompletionMs > 0 ? `${Math.round(stats.avgCompletionMs / 60000)}m` : '--'
 
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-handoff-flow">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+    <div style={ps.panelCard} data-testid="hub-handoff-flow">
+      <div style={ps.panelHeaderSpaced}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
           <GitPullRequest size={14} /> Agent Handoffs
         </div>
-        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
       </div>
 
-      {/* Stats row */}
-      <div className="grid grid-cols-4 gap-3 mb-4 p-3 bg-white/5 rounded-lg" data-testid="handoff-stats">
-        <StatCard label="Active" value={stats.active} color="text-green-400" />
-        <StatCard label="Completed" value={stats.completed} color="text-white/80" />
-        <StatCard label="Failed" value={stats.failed} color={stats.failed > 0 ? 'text-red-400' : 'text-white/40'} />
-        <StatCard label="Avg Time" value={avgTime} color="text-blue-400" />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px', marginBottom: '16px', padding: '12px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px' }} data-testid="handoff-stats">
+        <StatCard label="Active" value={stats.active} color="#4ade80" />
+        <StatCard label="Completed" value={stats.completed} color="rgba(255,255,255,0.8)" />
+        <StatCard label="Failed" value={stats.failed} color={stats.failed > 0 ? '#f87171' : 'rgba(255,255,255,0.4)'} />
+        <StatCard label="Avg Time" value={avgTime} color="#60a5fa" />
       </div>
 
-      {/* Active handoffs */}
-      <div className="mb-3">
-        <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">
-          Active ({active.length})
-        </div>
+      <div style={{ marginBottom: '12px' }}>
+        <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '8px' }}>Active ({active.length})</div>
         {active.length === 0 ? (
-          <div className="text-white/20 text-xs text-center py-2">No active handoffs</div>
+          <div style={{ ...ps.loadingState, paddingTop: '8px', paddingBottom: '8px' }}>No active handoffs</div>
         ) : (
-          <div className="space-y-2 max-h-40 overflow-y-auto">
+          <div style={{ ...ps.stackSm, maxHeight: '160px', overflowY: 'auto' }}>
             {active.map((h) => <HandoffCard key={h.handoff_id} handoff={h} />)}
           </div>
         )}
       </div>
 
-      {/* Recent completions */}
       {recent.length > 0 && (
         <div>
-          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">
-            Recent ({recent.length})
-          </div>
-          <div className="space-y-1.5 max-h-32 overflow-y-auto">
+          <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '8px' }}>Recent ({recent.length})</div>
+          <div style={{ ...ps.stackSm, gap: '6px', maxHeight: '128px', overflowY: 'auto' }}>
             {recent.slice(0, 5).map((h) => <HandoffCard key={h.handoff_id} handoff={h} />)}
           </div>
         </div>
       )}
 
-      {/* SLA compliance */}
       {stats.slaComplianceRate > 0 && (
-        <div className="mt-3 text-[10px] text-white/30 text-right">
-          SLA compliance: <span className={stats.slaComplianceRate >= 95 ? 'text-green-400' : stats.slaComplianceRate >= 80 ? 'text-amber-400' : 'text-red-400'}>
-            {stats.slaComplianceRate}%
-          </span>
+        <div style={{ marginTop: '12px', fontSize: '10px', color: 'rgba(255,255,255,0.3)', textAlign: 'right' }}>
+          SLA compliance: <span style={{ color: stats.slaComplianceRate >= 95 ? '#4ade80' : stats.slaComplianceRate >= 80 ? '#fbbf24' : '#f87171' }}>{stats.slaComplianceRate}%</span>
         </div>
       )}
     </div>

--- a/src/renderer/components/dashboard/HubDashboard.tsx
+++ b/src/renderer/components/dashboard/HubDashboard.tsx
@@ -1,5 +1,6 @@
-﻿// HubDashboard.tsx — Main dashboard container (Task Manager style)
+// HubDashboard.tsx — Main dashboard container (Task Manager style)
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { makeStyles } from '@fluentui/react-components'
 import { useHubMonitor } from '@/hooks/useHubMonitor'
 import { RateLimitPanel } from './RateLimitPanel'
 import { TokenActivityPanel } from './TokenActivityPanel'
@@ -28,7 +29,129 @@ interface Props {
 
 export type DashboardFocusSection = 'overview' | 'activity' | 'workflows' | 'billing' | 'auth' | 'audit' | 'requests'
 
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    backgroundColor: 'rgba(0,0,0,0.2)',
+    overflow: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingLeft: '24px',
+    paddingRight: '24px',
+    paddingTop: '10px',
+    paddingBottom: '10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: 'rgba(255,255,255,0.1)',
+    flexShrink: 0,
+  },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  headerRight: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  headerTitle: {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'rgba(255,255,255,0.8)',
+  },
+  headerEnterprise: {
+    fontSize: '12px',
+    color: 'rgba(255,255,255,0.3)',
+  },
+  headerScope: {
+    fontSize: '12px',
+    color: 'rgba(147,197,253,0.8)',
+  },
+  headerBtn: {
+    fontSize: '12px',
+    color: 'rgba(255,255,255,0.4)',
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    transitionProperty: 'color',
+    transitionDuration: '150ms',
+    ':hover': {
+      color: 'rgba(255,255,255,0.7)',
+    },
+  },
+  pendingBadge: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    fontSize: '10px',
+    backgroundColor: 'rgba(234,179,8,0.15)',
+    color: 'rgb(253,224,71)',
+    borderRadius: '999px',
+    paddingLeft: '8px',
+    paddingRight: '8px',
+    paddingTop: '2px',
+    paddingBottom: '2px',
+    cursor: 'pointer',
+    borderWidth: 0,
+    transitionProperty: 'background-color',
+    transitionDuration: '150ms',
+    ':hover': {
+      backgroundColor: 'rgba(234,179,8,0.25)',
+    },
+  },
+  timestamp: {
+    fontSize: '10px',
+    color: 'rgba(255,255,255,0.3)',
+  },
+  errorBanner: {
+    backgroundColor: 'rgba(239,68,68,0.1)',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: 'rgba(239,68,68,0.2)',
+    paddingLeft: '16px',
+    paddingRight: '16px',
+    paddingTop: '8px',
+    paddingBottom: '8px',
+    fontSize: '12px',
+    color: 'rgb(248,113,113)',
+  },
+  scrollArea: {
+    flex: 1,
+    overflowY: 'auto',
+    paddingLeft: '24px',
+    paddingRight: '24px',
+    paddingTop: '16px',
+    paddingBottom: '16px',
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: '16px',
+    maxWidth: '1152px',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    '@media (min-width: 1280px)': {
+      gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+  },
+  fullWidth: {
+    '@media (min-width: 1280px)': {
+      gridColumn: 'span 2',
+    },
+  },
+})
+
 export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialFocus = 'overview', initialFilters, onClose }: Props) {
+  const s = useStyles()
   const { snapshot, history, loading, error, lastUpdated, refresh: refreshMonitor } = useHubMonitor(enterprise)
   const [showAuth, setShowAuth] = useState(false)
   const [operationLog, setOperationLog] = useState<OperationLogEntry[]>([])
@@ -65,12 +188,8 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
     try {
       const reqs = await window.hubAPI.listActionRequests({ limit: 100 })
       const filtered = reqs.filter((request) => {
-        if (initialFilters?.state && request.state !== initialFilters.state) {
-          return false
-        }
-        if (initialFilters?.actor && request.actor !== initialFilters.actor) {
-          return false
-        }
+        if (initialFilters?.state && request.state !== initialFilters.state) return false
+        if (initialFilters?.actor && request.actor !== initialFilters.actor) return false
         return true
       })
       setActionRequests(filtered)
@@ -96,17 +215,13 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
       void refreshOperationLog()
       void refreshActionRequests()
     }, 5000)
-
     return () => clearInterval(timer)
   }, [refreshOperationLog, refreshActionRequests])
 
   useEffect(() => {
     return window.hubAPI.onOperationLogUpdated((entry) => {
       setOperationLog((current) => {
-        if (scopeLabel && entry.scope !== scopeLabel) {
-          return current
-        }
-
+        if (scopeLabel && entry.scope !== scopeLabel) return current
         const deduped = current.filter((item) => item.id !== entry.id)
         return [entry, ...deduped].slice(0, 100)
       })
@@ -133,37 +248,19 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
   }, [refreshActionRequests])
 
   const handleCopyShareLink = useCallback(async () => {
-    const link = buildDeepLink({
-      panel: initialFocus,
-      scopeRaw: scopeLabel || '',
-      filters: initialFilters,
-    })
-    try {
-      await navigator.clipboard.writeText(link)
-    } catch {
-      return
-    }
+    const link = buildDeepLink({ panel: initialFocus, scopeRaw: scopeLabel || '', filters: initialFilters })
+    try { await navigator.clipboard.writeText(link) } catch { return }
     setShareCopied(true)
-    if (shareCopiedTimerRef.current) {
-      clearTimeout(shareCopiedTimerRef.current)
-    }
-    shareCopiedTimerRef.current = setTimeout(() => {
-      setShareCopied(false)
-    }, 2000)
+    if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current)
+    shareCopiedTimerRef.current = setTimeout(() => setShareCopied(false), 2000)
   }, [initialFocus, initialFilters, scopeLabel])
 
   useEffect(() => () => {
-    if (shareCopiedTimerRef.current) {
-      clearTimeout(shareCopiedTimerRef.current)
-    }
+    if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current)
   }, [])
 
   useEffect(() => {
-    if (initialFocus === 'auth') {
-      setShowAuth(true)
-      return
-    }
-
+    if (initialFocus === 'auth') { setShowAuth(true); return }
     const targetRef =
       initialFocus === 'activity' ? activityRef
       : initialFocus === 'workflows' ? workflowsRef
@@ -171,125 +268,83 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
       : initialFocus === 'audit' ? auditRef
       : initialFocus === 'requests' ? requestsRef
       : overviewRef
-
     targetRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [initialFocus])
 
+  const pendingCount = actionRequests.filter((r) => r.state === 'pending').length
+
   return (
-    <div className="flex flex-col h-full bg-black/20 overflow-hidden">
+    <div className={s.root}>
       {/* Header bar */}
-      <div className="flex items-center justify-between px-6 py-2.5 border-b border-white/10 flex-shrink-0">
-        <div className="flex items-center gap-3">
-          <span className="text-sm font-semibold text-white/80">AgentCraftworks Hub</span>
-          <span className="text-xs text-white/30">{enterprise} Enterprise</span>
-          {scopeLabel && <span className="text-xs text-blue-300/80">Scope: {scopeLabel}</span>}
+      <div className={s.header}>
+        <div className={s.headerLeft}>
+          <span className={s.headerTitle}>AgentCraftworks Hub</span>
+          <span className={s.headerEnterprise}>{enterprise} Enterprise</span>
+          {scopeLabel && <span className={s.headerScope}>Scope: {scopeLabel}</span>}
         </div>
-        <div className="flex items-center gap-3">
+        <div className={s.headerRight}>
           {onClose && (
-            <button
-              onClick={onClose}
-              className="text-xs text-white/50 hover:text-white/80 transition-colors"
-              title="Return to main view"
-            >
+            <button type="button" onClick={onClose} className={s.headerBtn} title="Return to main view">
               Back to Main
             </button>
           )}
-          {actionRequests.filter((r) => r.state === 'pending').length > 0 && (
-            <button
-              onClick={() => requestsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-              className="flex items-center gap-1 text-[10px] bg-yellow-500/15 text-yellow-300 rounded-full px-2 py-0.5 hover:bg-yellow-500/25 transition-colors"
-              title="Scroll to pending action requests"
-            >
+          {pendingCount > 0 && (
+            <button type="button" onClick={() => requestsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })} className={s.pendingBadge} title="Scroll to pending action requests">
               <ShieldAlert size={10} />
-              {actionRequests.filter((r) => r.state === 'pending').length} pending
+              {pendingCount} pending
             </button>
           )}
           {lastUpdated && (
-            <span className="text-[10px] text-white/30">
-              Updated {lastUpdated.toLocaleTimeString()}
-            </span>
+            <span className={s.timestamp}>Updated {lastUpdated.toLocaleTimeString()}</span>
           )}
           <button
-            onClick={() => setShowAuth(s => !s)}
-            className={`flex items-center gap-1.5 text-xs transition-colors ${showAuth ? 'text-blue-400' : 'text-white/40 hover:text-white/70'}`}
+            type="button"
+            onClick={() => setShowAuth(prev => !prev)}
+            className={s.headerBtn}
+            style={{ color: showAuth ? 'rgb(96,165,250)' : undefined }}
             title="Configure GitHub token"
           >
             <Settings size={12} />
             Auth
           </button>
-          <button
-            onClick={handleCopyShareLink}
-            className="text-xs text-white/40 hover:text-white/70 transition-colors"
-            title="Copy deep-link"
-          >
+          <button type="button" onClick={handleCopyShareLink} className={s.headerBtn} title="Copy deep-link">
             {shareCopied ? 'Copied' : 'Share'}
           </button>
-          <button
-            onClick={refreshAll}
-            disabled={loading}
-            className="flex items-center gap-1.5 text-xs text-white/40 hover:text-white/70 transition-colors disabled:opacity-40"
-          >
-            {loading
-              ? <Loader size={12} className="animate-spin" />
-              : <RefreshCw size={12} />}
+          <button type="button" onClick={refreshAll} disabled={loading} className={s.headerBtn} style={{ opacity: loading ? 0.4 : undefined }}>
+            {loading ? <Loader size={12} style={{ animation: 'spin 1s linear infinite' }} /> : <RefreshCw size={12} />}
             Refresh
           </button>
         </div>
       </div>
 
-      {/* Error banner */}
-      {error && (
-        <div className="bg-red-500/10 border-b border-red-500/20 px-4 py-2 text-xs text-red-400">
-          {error}
-        </div>
-      )}
+      {error && <div className={s.errorBanner}>{error}</div>}
 
       {/* Dashboard grid */}
-      <div className="flex-1 overflow-y-auto px-6 py-4">
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 max-w-6xl mx-auto">
-
-          {/* Auth settings panel — shown when settings gear is clicked */}
+      <div className={s.scrollArea}>
+        <div className={s.grid}>
           {showAuth && (
-            <div className="xl:col-span-2">
+            <div className={s.fullWidth}>
               <TokenAuthPanel onSaved={() => setShowAuth(false)} />
             </div>
           )}
 
-          {/* Rate Limit — always full width on smaller, left col on xl */}
-          <div ref={overviewRef} className="xl:col-span-1">
-            <RateLimitPanel
-              data={snapshot?.rateLimit ?? null}
-              history={history}
-              onRefresh={refreshAll}
-            />
+          <div ref={overviewRef}>
+            <RateLimitPanel data={snapshot?.rateLimit ?? null} history={history} onRefresh={refreshAll} />
           </div>
 
-          {/* Rate Governor — governance layer beside raw rate limit */}
-          <div className="xl:col-span-1">
-            <RateGovernorPanel
-              data={snapshot?.rateGovernor ?? null}
-              onRefresh={refreshAll}
-            />
+          <div>
+            <RateGovernorPanel data={snapshot?.rateGovernor ?? null} onRefresh={refreshAll} />
           </div>
 
-          {/* Agent Handoff Flow — full width */}
-          <div className="xl:col-span-2">
-            <HandoffFlowPanel
-              data={snapshot?.handoffs ?? null}
-              onRefresh={refreshAll}
-            />
+          <div className={s.fullWidth}>
+            <HandoffFlowPanel data={snapshot?.handoffs ?? null} onRefresh={refreshAll} />
           </div>
 
-          {/* Squad Coordinator — full width */}
-          <div className="xl:col-span-2">
-            <SquadCoordinatorPanel
-              data={snapshot?.squadState ?? null}
-              onRefresh={refreshAll}
-            />
+          <div className={s.fullWidth}>
+            <SquadCoordinatorPanel data={snapshot?.squadState ?? null} onRefresh={refreshAll} />
           </div>
 
-          {/* Token Activity */}
-          <div ref={activityRef} className="xl:col-span-1">
+          <div ref={activityRef}>
             <TokenActivityPanel
               topCallers={snapshot?.topCallers ?? []}
               topCallers1h={snapshot?.topCallers1h ?? []}
@@ -299,45 +354,27 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
             />
           </div>
 
-          {/* Actions Minutes */}
-          <div className="xl:col-span-1">
+          <div>
             <ActionsMinutesPanel data={snapshot?.billing ?? null} />
           </div>
 
-          {/* Copilot Usage */}
-          <div className="xl:col-span-1">
+          <div>
             <CopilotUsagePanel data={snapshot?.copilot ?? null} />
           </div>
 
-          {/* Workflow Health */}
-          <div ref={workflowsRef} className="xl:col-span-2">
-            <WorkflowHealthPanel
-              entries={operationLog}
-              actionRequests={actionRequests}
-              lastUpdated={lastUpdated}
-              onRefresh={refreshAll}
-            />
+          <div ref={workflowsRef} className={s.fullWidth}>
+            <WorkflowHealthPanel entries={operationLog} actionRequests={actionRequests} lastUpdated={lastUpdated} onRefresh={refreshAll} />
           </div>
 
-          {/* Billing — spans full width */}
-          <div ref={billingRef} className="xl:col-span-2">
-            <BillingPanel
-              billing={snapshot?.billing ?? null}
-              copilot={snapshot?.copilot ?? null}
-            />
+          <div ref={billingRef} className={s.fullWidth}>
+            <BillingPanel billing={snapshot?.billing ?? null} copilot={snapshot?.copilot ?? null} />
           </div>
 
-          {/* Operation Log */}
-          <div ref={auditRef} className="xl:col-span-2">
-            <OperationLogPanel
-              entries={operationLog}
-              loading={operationLogLoading}
-              onRefresh={refreshOperationLog}
-            />
+          <div ref={auditRef} className={s.fullWidth}>
+            <OperationLogPanel entries={operationLog} loading={operationLogLoading} onRefresh={refreshOperationLog} />
           </div>
 
-          {/* Action Request Queue */}
-          <div ref={requestsRef} className="xl:col-span-2">
+          <div ref={requestsRef} className={s.fullWidth}>
             <ActionRequestPanel
               requests={actionRequests}
               canApprove={authority?.capabilities.includes('approve_action') ?? false}

--- a/src/renderer/components/dashboard/HubDashboard.tsx
+++ b/src/renderer/components/dashboard/HubDashboard.tsx
@@ -1,6 +1,6 @@
 // HubDashboard.tsx — Main dashboard container (Task Manager style)
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { makeStyles } from '@fluentui/react-components'
+import { makeStyles, Spinner } from '@fluentui/react-components'
 import { useHubMonitor } from '@/hooks/useHubMonitor'
 import { RateLimitPanel } from './RateLimitPanel'
 import { TokenActivityPanel } from './TokenActivityPanel'
@@ -14,7 +14,7 @@ import { WorkflowHealthPanel } from './WorkflowHealthPanel'
 import { RateGovernorPanel } from './RateGovernorPanel'
 import { HandoffFlowPanel } from './HandoffFlowPanel'
 import { SquadCoordinatorPanel } from './SquadCoordinatorPanel'
-import { RefreshCw, Loader, Settings, ShieldAlert } from 'lucide-react'
+import { RefreshCw, Settings, ShieldAlert } from 'lucide-react'
 import type { ActionRequest, ActionAuthoritySnapshot, OperationLogEntry } from '@shared/hub-types'
 import { buildDeepLink } from '@shared/hub-contracts'
 import type { HubDeepLinkFilters } from '@shared/hub-contracts'
@@ -311,7 +311,7 @@ export function HubDashboard({ enterprise = 'AICraftWorks', scopeLabel, initialF
             {shareCopied ? 'Copied' : 'Share'}
           </button>
           <button type="button" onClick={refreshAll} disabled={loading} className={s.headerBtn} style={{ opacity: loading ? 0.4 : undefined }}>
-            {loading ? <Loader size={12} style={{ animation: 'spin 1s linear infinite' }} /> : <RefreshCw size={12} />}
+            {loading ? <Spinner size="extra-small" /> : <RefreshCw size={12} />}
             Refresh
           </button>
         </div>

--- a/src/renderer/components/dashboard/RateGovernorPanel.tsx
+++ b/src/renderer/components/dashboard/RateGovernorPanel.tsx
@@ -1,6 +1,7 @@
 // RateGovernorPanel.tsx — Traffic light zone, quota pools, priority tiers, circuit breakers
 import type { HubRateGovernorData } from '@shared/hub-types'
-import { RefreshCw, Shield, Zap } from 'lucide-react'
+import { RefreshCw, Shield } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface Props {
   data: HubRateGovernorData | null
@@ -8,29 +9,29 @@ interface Props {
 }
 
 const zoneColors = {
-  GREEN: { bg: 'bg-green-500', glow: 'shadow-green-500/40', text: 'text-green-400', label: 'Normal' },
-  AMBER: { bg: 'bg-amber-500', glow: 'shadow-amber-500/40', text: 'text-amber-400', label: 'Pressure' },
-  RED: { bg: 'bg-red-500', glow: 'shadow-red-500/40', text: 'text-red-400', label: 'Critical' },
+  GREEN: { bg: '#22c55e', glow: '0 0 8px rgba(34,197,94,0.4)', text: '#4ade80', label: 'Normal' },
+  AMBER: { bg: '#f59e0b', glow: '0 0 8px rgba(245,158,11,0.4)', text: '#fbbf24', label: 'Pressure' },
+  RED: { bg: '#ef4444', glow: '0 0 8px rgba(239,68,68,0.4)', text: '#f87171', label: 'Critical' },
 } as const
 
 const circuitLabels = {
-  CLOSED: { text: 'text-green-400', label: '●' },
-  PRE_EMPTIVE_OPEN: { text: 'text-amber-400', label: '◐' },
-  HALF_OPEN: { text: 'text-amber-400', label: '◑' },
-  OPEN: { text: 'text-red-400', label: '○' },
+  CLOSED: { text: '#4ade80', label: '●' },
+  PRE_EMPTIVE_OPEN: { text: '#fbbf24', label: '◐' },
+  HALF_OPEN: { text: '#fbbf24', label: '◑' },
+  OPEN: { text: '#f87171', label: '○' },
 } as const
 
 function QuotaBar({ label, remaining, total }: { label: string; remaining: number; total: number }) {
   const pct = total > 0 ? (remaining / total) * 100 : 0
-  const color = pct > 40 ? 'bg-green-500' : pct > 15 ? 'bg-amber-500' : 'bg-red-500'
+  const color = pct > 40 ? '#22c55e' : pct > 15 ? '#f59e0b' : '#ef4444'
   return (
-    <div className="space-y-1">
-      <div className="flex justify-between text-xs">
-        <span className="text-white/60">{label}</span>
-        <span className="text-white/80 tabular-nums">{remaining.toLocaleString()} / {total.toLocaleString()}</span>
+    <div style={{ ...ps.stackSm, gap: '4px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px' }}>
+        <span style={ps.textSecondary}>{label}</span>
+        <span style={{ ...ps.textPrimary, fontVariantNumeric: 'tabular-nums' }}>{remaining.toLocaleString()} / {total.toLocaleString()}</span>
       </div>
-      <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
-        <div className={`h-full rounded-full transition-all duration-500 ${color}`} style={{ width: `${Math.max(pct, 1)}%` }} />
+      <div style={{ ...ps.thinBarTrack, height: '6px' }}>
+        <div style={{ height: '100%', borderRadius: '999px', transition: 'width 500ms', backgroundColor: color, width: `${Math.max(pct, 1)}%` }} />
       </div>
     </div>
   )
@@ -38,16 +39,16 @@ function QuotaBar({ label, remaining, total }: { label: string; remaining: numbe
 
 function PriorityBadge({ tier, zone }: { tier: 'P0' | 'P1' | 'P2'; zone: 'GREEN' | 'AMBER' | 'RED' }) {
   const status =
-    tier === 'P0' ? { label: 'Active', color: 'text-green-400' } :
-    tier === 'P1' ? (zone === 'RED' ? { label: 'Constrained', color: 'text-amber-400' } : { label: 'Active', color: 'text-green-400' }) :
-    zone === 'RED' ? { label: 'Parked', color: 'text-red-400' } :
-    zone === 'AMBER' ? { label: 'Throttled', color: 'text-amber-400' } :
-    { label: 'Active', color: 'text-green-400' }
+    tier === 'P0' ? { label: 'Active', color: '#4ade80' } :
+    tier === 'P1' ? (zone === 'RED' ? { label: 'Constrained', color: '#fbbf24' } : { label: 'Active', color: '#4ade80' }) :
+    zone === 'RED' ? { label: 'Parked', color: '#f87171' } :
+    zone === 'AMBER' ? { label: 'Throttled', color: '#fbbf24' } :
+    { label: 'Active', color: '#4ade80' }
 
   return (
-    <div className="flex items-center justify-between text-xs" data-testid={`hub-priority-${tier.toLowerCase()}`}>
-      <span className="text-white/60 font-mono">{tier}</span>
-      <span className={`font-medium ${status.color}`}>{status.label}</span>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: '12px' }} data-testid={`hub-priority-${tier.toLowerCase()}`}>
+      <span style={{ ...ps.textSecondary, fontFamily: 'monospace' }}>{tier}</span>
+      <span style={{ fontWeight: 500, color: status.color }}>{status.label}</span>
     </div>
   )
 }
@@ -55,14 +56,14 @@ function PriorityBadge({ tier, zone }: { tier: 'P0' | 'P1' | 'P2'; zone: 'GREEN'
 export function RateGovernorPanel({ data, onRefresh }: Props) {
   if (!data) {
     return (
-      <div className="bg-white/5 rounded-xl p-4 border border-white/10" data-testid="hub-rate-governor">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+      <div style={ps.panelCard} data-testid="hub-rate-governor">
+        <div style={ps.panelHeaderSpaced}>
+          <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
             <Shield size={14} /> Rate Governor
           </div>
-          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+          <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
         </div>
-        <div className="text-white/30 text-xs text-center py-6">No rate governor data</div>
+        <div style={{ ...ps.loadingState, paddingTop: '24px', paddingBottom: '24px' }}>No rate governor data</div>
       </div>
     )
   }
@@ -71,77 +72,76 @@ export function RateGovernorPanel({ data, onRefresh }: Props) {
   const zone = zoneColors[state.trafficLight]
 
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10" data-testid="hub-rate-governor">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+    <div style={ps.panelCard} data-testid="hub-rate-governor">
+      <div style={ps.panelHeaderSpaced}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
           <Shield size={14} /> Rate Governor
         </div>
-        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
       </div>
 
       {/* Traffic Light */}
-      <div className="flex items-center gap-3 mb-4">
-        <div className="flex gap-1.5">
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
+        <div style={{ display: 'flex', gap: '6px' }}>
           {(['GREEN', 'AMBER', 'RED'] as const).map((z) => (
             <div
               key={z}
-              className={`w-5 h-5 rounded-full transition-all ${
-                z === state.trafficLight
-                  ? `${zoneColors[z].bg} ${zoneColors[z].glow} shadow-lg`
-                  : 'bg-white/10'
-              }`}
+              style={{
+                width: '20px', height: '20px', borderRadius: '50%', transition: 'all 300ms',
+                backgroundColor: z === state.trafficLight ? zoneColors[z].bg : 'rgba(255,255,255,0.1)',
+                boxShadow: z === state.trafficLight ? zoneColors[z].glow : 'none',
+              }}
               data-testid={`hub-zone-${z.toLowerCase()}`}
             />
           ))}
         </div>
         <div>
-          <span className={`text-lg font-bold ${zone.text}`} data-testid="hub-zone-label">{state.trafficLight}</span>
-          <span className="text-white/40 text-xs ml-2">{zone.label}</span>
+          <span style={{ fontSize: '18px', fontWeight: 700, color: zone.text }} data-testid="hub-zone-label">{state.trafficLight}</span>
+          <span style={{ ...ps.textMuted, fontSize: '12px', marginLeft: '8px' }}>{zone.label}</span>
         </div>
       </div>
 
       {/* Quota Pools */}
-      <div className="space-y-2 mb-4" data-testid="hub-quota-pools">
+      <div style={{ ...ps.stackSm, marginBottom: '16px' }} data-testid="hub-quota-pools">
         <QuotaBar label="GitHub" remaining={github.windowRemaining} total={github.windowTotal} />
         <QuotaBar label="Copilot" remaining={copilot.windowRemaining} total={copilot.windowTotal} />
       </div>
 
       {/* Priority Tiers */}
-      <div className="space-y-1.5 mb-4" data-testid="hub-priority-tiers">
-        <div className="text-[10px] text-white/40 uppercase tracking-wider">Priority Tiers</div>
+      <div style={{ ...ps.stackSm, gap: '6px', marginBottom: '16px' }} data-testid="hub-priority-tiers">
+        <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Priority Tiers</div>
         <PriorityBadge tier="P0" zone={state.trafficLight} />
         <PriorityBadge tier="P1" zone={state.trafficLight} />
         <PriorityBadge tier="P2" zone={state.trafficLight} />
       </div>
 
       {/* Circuit Breakers */}
-      <div className="flex items-center gap-3 text-xs mb-3" data-testid="hub-circuits">
-        <span className="text-white/40">Circuits:</span>
-        <span className={circuitLabels[state.circuitStateByQuota.github].text}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', fontSize: '12px', marginBottom: '12px' }} data-testid="hub-circuits">
+        <span style={ps.textMuted}>Circuits:</span>
+        <span style={{ color: circuitLabels[state.circuitStateByQuota.github].text }}>
           {circuitLabels[state.circuitStateByQuota.github].label} GitHub
         </span>
-        <span className={circuitLabels[state.circuitStateByQuota.copilot].text}>
+        <span style={{ color: circuitLabels[state.circuitStateByQuota.copilot].text }}>
           {circuitLabels[state.circuitStateByQuota.copilot].label} Copilot
         </span>
         {state.cascadeMode === 'sequential' && (
-          <span className="text-amber-400">◐ Sequential</span>
+          <span style={{ color: '#fbbf24' }}>◐ Sequential</span>
         )}
       </div>
 
-      {/* Agent Tokens (compact) */}
+      {/* Agent Tokens */}
       {agents.length > 0 && (
         <div data-testid="hub-agent-tokens">
-          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-1">Agents ({agents.length})</div>
-          <div className="space-y-1 max-h-28 overflow-y-auto">
+          <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '4px' }}>Agents ({agents.length})</div>
+          <div style={{ ...ps.stackSm, gap: '4px', maxHeight: '112px', overflowY: 'auto' }}>
             {agents.map((a) => {
               const utilPct = a.reserved > 0 ? Math.round((a.used / a.reserved) * 100) : 0
               return (
-                <div key={a.agentId} className="flex items-center justify-between text-[11px]">
-                  <span className="text-white/60 font-mono truncate max-w-[120px]">{a.agentId}</span>
-                  <div className="flex items-center gap-2">
-                    <span className="text-white/40">{a.priority}</span>
-                    <span className={`tabular-nums ${utilPct > 80 ? 'text-red-400' : utilPct > 50 ? 'text-amber-400' : 'text-green-400'}`}>
+                <div key={a.agentId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: '11px' }}>
+                  <span style={{ color: 'rgba(255,255,255,0.6)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '120px' }}>{a.agentId}</span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    <span style={ps.textMuted}>{a.priority}</span>
+                    <span style={{ fontVariantNumeric: 'tabular-nums', color: utilPct > 80 ? '#f87171' : utilPct > 50 ? '#fbbf24' : '#4ade80' }}>
                       {utilPct}%
                     </span>
                   </div>

--- a/src/renderer/components/dashboard/RateLimitPanel.tsx
+++ b/src/renderer/components/dashboard/RateLimitPanel.tsx
@@ -1,8 +1,9 @@
-﻿// RateLimitPanel.tsx — GitHub API rate limit gauge, sparkline, and countdown
+// RateLimitPanel.tsx — GitHub API rate limit gauge, sparkline, and countdown
 import { useState } from 'react'
 import type { RateLimitData, RateLimitSample } from '@shared/hub-types'
 import { AreaChart, Area, Tooltip, ResponsiveContainer, XAxis } from 'recharts'
 import { RefreshCw, Zap, Clock } from 'lucide-react'
+import * as ps from './panel-styles'
 
 type TimeRange = '1h' | '6h' | 'all'
 
@@ -25,14 +26,13 @@ function formatTime(ts: number): string {
 
 function UsageBar({ used, limit, color }: { used: number; limit: number; color: string }) {
   const pct = limit > 0 ? Math.round((used / limit) * 100) : 0
-  const barColor =
-    pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : color
+  const barColor = pct >= 90 ? '#ef4444' : pct >= 70 ? '#f59e0b' : color
   return (
-    <div className="flex items-center gap-2 text-xs">
-      <div className="flex-1 h-1.5 bg-white/10 rounded-full overflow-hidden">
-        <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+    <div style={{ ...ps.flexRow, fontSize: '12px' }}>
+      <div style={{ ...ps.thinBarTrack, flex: 1, height: '6px' }}>
+        <div style={{ height: '100%', borderRadius: '999px', transition: 'width 300ms', backgroundColor: barColor, width: `${pct}%` }} />
       </div>
-      <span className="tabular-nums text-white/60 w-20 text-right">
+      <span style={{ fontVariantNumeric: 'tabular-nums', color: 'rgba(255,255,255,0.6)', width: '80px', textAlign: 'right' }}>
         {used.toLocaleString()} / {limit.toLocaleString()}
       </span>
     </div>
@@ -52,79 +52,59 @@ export function RateLimitPanel({ data, history, onRefresh }: Props) {
   if (!data) {
     return (
       <PanelShell title="API Rate Limits" icon={<Zap size={14} />} onRefresh={onRefresh}>
-        <div className="text-white/40 text-sm flex items-center justify-center h-24">Loading…</div>
+        <div style={{ ...ps.loadingState, height: '96px' }}>Loading…</div>
       </PanelShell>
     )
   }
 
   const { core, search, graphql, codeSearch } = data
   const corePct = Math.round((core.used / core.limit) * 100)
-
-  // Merge in-memory data.history (number[]) with persisted RateLimitSample[] history
-  // data.history is just coreUsed values without timestamps — use for live tail only when full history is empty
   const fullHistory = filterHistory(history, range)
   const chartData = fullHistory.length > 1
     ? fullHistory.map(s => ({ ts: s.ts, used: s.coreUsed, label: formatTime(s.ts) }))
     : data.history.map((used, i) => ({ ts: i, used, label: '' }))
-
-  // Tick labels: show every ~10th point to avoid crowding
   const tickInterval = Math.max(1, Math.floor(chartData.length / 6))
 
   return (
     <PanelShell title="API Rate Limits" icon={<Zap size={14} />} onRefresh={onRefresh}>
-      {/* Core gauge + current stats */}
-      <div className="flex items-center gap-4 mb-4">
-        <div className="relative flex-shrink-0 w-20 h-20">
-          <svg viewBox="0 0 36 36" className="w-full h-full -rotate-90">
+      {/* Core gauge + stats */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '16px' }}>
+        <div style={{ position: 'relative', flexShrink: 0, width: '80px', height: '80px' }}>
+          <svg viewBox="0 0 36 36" style={{ width: '100%', height: '100%', transform: 'rotate(-90deg)' }}>
             <circle cx="18" cy="18" r="15" fill="none" stroke="white" strokeOpacity="0.1" strokeWidth="3" />
-            <circle
-              cx="18" cy="18" r="15" fill="none"
+            <circle cx="18" cy="18" r="15" fill="none"
               stroke={corePct >= 90 ? '#ef4444' : corePct >= 70 ? '#f59e0b' : '#22c55e'}
-              strokeWidth="3"
-              strokeDasharray={`${corePct * 0.942} 94.2`}
-              strokeLinecap="round"
-            />
+              strokeWidth="3" strokeDasharray={`${corePct * 0.942} 94.2`} strokeLinecap="round" />
           </svg>
-          <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-            <span className="text-lg font-bold leading-none">{corePct}%</span>
-            <span className="text-[9px] text-white/50 mt-0.5">used</span>
+          <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}>
+            <span style={{ fontSize: '18px', fontWeight: 700, lineHeight: 1 }}>{corePct}%</span>
+            <span style={{ fontSize: '9px', color: 'rgba(255,255,255,0.5)', marginTop: '2px' }}>used</span>
           </div>
         </div>
-
-        <div className="flex-1 space-y-1.5">
-          <div className="text-xs text-white/50">Core REST</div>
-          <UsageBar used={core.used} limit={core.limit} color="bg-blue-500" />
-          <div className="text-xs text-white/40">
-            {core.remaining.toLocaleString()} remaining · resets in{' '}
-            <span className="text-white/70 font-mono">{formatEta(core.resetEtaMs)}</span>
+        <div style={{ flex: 1, ...ps.stackSm, gap: '6px' }}>
+          <div style={{ fontSize: '12px', color: 'rgba(255,255,255,0.5)' }}>Core REST</div>
+          <UsageBar used={core.used} limit={core.limit} color="#3b82f6" />
+          <div style={{ fontSize: '12px', color: 'rgba(255,255,255,0.4)' }}>
+            {core.remaining.toLocaleString()} remaining · resets in <span style={{ color: 'rgba(255,255,255,0.7)', fontFamily: 'monospace' }}>{formatEta(core.resetEtaMs)}</span>
           </div>
-          <div className="text-xs text-white/30 flex items-center gap-1">
-            <Clock size={9} />
-            {core.limit.toLocaleString()} calls/hr · enterprise quota
+          <div style={{ fontSize: '12px', color: 'rgba(255,255,255,0.3)', display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <Clock size={9} /> {core.limit.toLocaleString()} calls/hr · enterprise quota
           </div>
         </div>
       </div>
 
-      {/* History chart with range selector */}
-      <div className="mb-4">
-        <div className="flex items-center justify-between mb-1">
-          <div className="text-[10px] text-white/30">
-            Core usage history ({chartData.length} samples)
-          </div>
-          <div className="flex gap-1">
+      {/* History chart */}
+      <div style={{ marginBottom: '16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
+          <div style={ps.finePrint}>Core usage history ({chartData.length} samples)</div>
+          <div style={{ display: 'flex', gap: '4px' }}>
             {(['1h', '6h', 'all'] as TimeRange[]).map(r => (
-              <button
-                key={r}
-                onClick={() => setRange(r)}
-                className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${range === r ? 'bg-blue-500/30 text-blue-300' : 'text-white/30 hover:text-white/60'}`}
-              >
-                {r}
-              </button>
+              <button key={r} type="button" onClick={() => setRange(r)} style={range === r ? ps.tabActive : ps.tabInactive}>{r}</button>
             ))}
           </div>
         </div>
         {chartData.length > 1 ? (
-          <div className="h-16">
+          <div style={{ height: '64px' }}>
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={chartData} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
                 <defs>
@@ -133,45 +113,26 @@ export function RateLimitPanel({ data, history, onRefresh }: Props) {
                     <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
                   </linearGradient>
                 </defs>
-                <XAxis
-                  dataKey="label"
-                  tick={{ fill: 'rgba(255,255,255,0.25)', fontSize: 9 }}
-                  tickLine={false}
-                  axisLine={false}
-                  interval={tickInterval}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="used"
-                  stroke="#3b82f6"
-                  strokeWidth={1.5}
-                  fill="url(#rateGrad)"
-                  dot={false}
-                />
-                <Tooltip
-                  contentStyle={{ background: '#1f2937', border: 'none', borderRadius: 4, fontSize: 11 }}
-                  formatter={(v: number) => [`${v.toLocaleString()} used`, '']}
-                  labelFormatter={(label) => label || ''}
-                />
+                <XAxis dataKey="label" tick={{ fill: 'rgba(255,255,255,0.25)', fontSize: 9 }} tickLine={false} axisLine={false} interval={tickInterval} />
+                <Area type="monotone" dataKey="used" stroke="#3b82f6" strokeWidth={1.5} fill="url(#rateGrad)" dot={false} />
+                <Tooltip contentStyle={{ background: '#1f2937', border: 'none', borderRadius: 4, fontSize: 11 }} formatter={(v: number) => [`${v.toLocaleString()} used`, '']} labelFormatter={(label) => label || ''} />
               </AreaChart>
             </ResponsiveContainer>
           </div>
         ) : (
-          <div className="h-8 flex items-center text-[10px] text-white/20">
-            Collecting history… (polls every 30s)
-          </div>
+          <div style={{ height: '32px', display: 'flex', alignItems: 'center', ...ps.finePrint }}>Collecting history… (polls every 30s)</div>
         )}
       </div>
 
       {/* Secondary endpoints */}
-      <div className="space-y-2 border-t border-white/5 pt-3">
+      <div style={{ ...ps.stackSm, borderTop: '1px solid rgba(255,255,255,0.05)', paddingTop: '12px' }}>
         {[
-          { label: 'Search', ep: search, color: 'bg-purple-500' },
-          { label: 'GraphQL', ep: graphql, color: 'bg-cyan-500' },
-          { label: 'Code Search', ep: codeSearch, color: 'bg-orange-500' },
+          { label: 'Search', ep: search, color: '#a855f7' },
+          { label: 'GraphQL', ep: graphql, color: '#06b6d4' },
+          { label: 'Code Search', ep: codeSearch, color: '#f97316' },
         ].map(({ label, ep, color }) => (
           <div key={label}>
-            <div className="text-[10px] text-white/40 mb-0.5">{label}</div>
+            <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', marginBottom: '2px' }}>{label}</div>
             <UsageBar used={ep.used} limit={ep.limit} color={color} />
           </div>
         ))}
@@ -180,28 +141,12 @@ export function RateLimitPanel({ data, history, onRefresh }: Props) {
   )
 }
 
-// Shared panel shell
-function PanelShell({
-  title,
-  icon,
-  onRefresh,
-  children,
-}: {
-  title: string
-  icon: React.ReactNode
-  onRefresh: () => void
-  children: React.ReactNode
-}) {
+function PanelShell({ title, icon, onRefresh, children }: { title: string; icon: React.ReactNode; onRefresh: () => void; children: React.ReactNode }) {
   return (
-    <div className="bg-white/5 rounded-xl p-4 flex flex-col gap-1 border border-white/10">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
-          {icon}
-          {title}
-        </div>
-        <button onClick={onRefresh} className="text-white/30 hover:text-white/70 transition-colors">
-          <RefreshCw size={12} />
-        </button>
+    <div style={ps.panelCardFlex}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 600, color: 'rgba(255,255,255,0.8)' }}>{icon}{title}</div>
+        <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
       </div>
       {children}
     </div>

--- a/src/renderer/components/dashboard/SquadCoordinatorPanel.tsx
+++ b/src/renderer/components/dashboard/SquadCoordinatorPanel.tsx
@@ -1,55 +1,48 @@
 // SquadCoordinatorPanel.tsx — Squad overview, S2S communication, routing decisions, engagement gate
 import type { HubSquadData, HubSquadInfo, HubRoutingDecision, HubSquadHandoff } from '@shared/hub-types'
 import { RefreshCw, Users, ArrowRight } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface Props {
   data: HubSquadData | null
   onRefresh: () => void
 }
 
-const dialColors = ['', 'text-gray-400', 'text-blue-400', 'text-green-400', 'text-amber-400', 'text-red-400']
+const dialColors = ['', '#9ca3af', '#60a5fa', '#4ade80', '#fbbf24', '#f87171']
 const dialLabels = ['', 'Observer', 'Advisor', 'Peer', 'Agent Team', 'Full Agent']
 
-const responseModeColors = {
-  DIRECT: 'text-green-400',
-  LIGHTWEIGHT: 'text-blue-400',
-  STANDARD: 'text-amber-400',
-  FULL: 'text-red-400',
+const responseModeColors: Record<string, string> = {
+  DIRECT: '#4ade80', LIGHTWEIGHT: '#60a5fa', STANDARD: '#fbbf24', FULL: '#f87171',
 }
 
-const handoffTypeStyles = {
-  'request-response': { arrow: '→', style: 'border-blue-500/30' },
-  'scatter-gather': { arrow: '⇉', style: 'border-amber-500/30' },
-  'event-broadcast': { arrow: '⟶', style: 'border-white/10 border-dashed' },
+const handoffTypeStyles: Record<string, { arrow: string; border: string }> = {
+  'request-response': { arrow: '→', border: '1px solid rgba(59,130,246,0.3)' },
+  'scatter-gather': { arrow: '⇉', border: '1px solid rgba(245,158,11,0.3)' },
+  'event-broadcast': { arrow: '⟶', border: '1px dashed rgba(255,255,255,0.1)' },
 }
 
 function SquadCard({ squad }: { squad: HubSquadInfo }) {
   return (
-    <div className="bg-white/5 rounded-lg p-3 border border-white/10" data-testid={`squad-${squad.squadId}`}>
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <Users size={12} className="text-white/40" />
-          <span className="text-white/80 text-xs font-medium">{squad.squadId}</span>
+    <div style={{ background: 'rgba(255,255,255,0.05)', borderRadius: '8px', padding: '12px', border: '1px solid rgba(255,255,255,0.1)' }} data-testid={`squad-${squad.squadId}`}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+        <div style={{ ...ps.flexRow, gap: '8px' }}>
+          <Users size={12} style={{ color: 'rgba(255,255,255,0.4)' }} />
+          <span style={{ ...ps.textPrimary, fontSize: '12px', fontWeight: 500 }}>{squad.squadId}</span>
         </div>
-        <span className="text-[10px] text-white/40">
-          Cap: L{squad.ceiling} <span className={dialColors[squad.ceiling]}>{dialLabels[squad.ceiling]}</span>
+        <span style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)' }}>
+          Cap: L{squad.ceiling} <span style={{ color: dialColors[squad.ceiling] }}>{dialLabels[squad.ceiling]}</span>
         </span>
       </div>
-      {/* Agent dial indicators */}
-      <div className="flex flex-wrap gap-1.5">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
         {squad.agents.map((a) => (
-          <div key={a.id} className="flex items-center gap-1 bg-white/5 rounded px-1.5 py-0.5" title={`${a.name} — L${a.engagementLevel} ${a.priority}`}>
-            <div className={`w-1.5 h-1.5 rounded-full ${
-              a.engagementLevel >= 4 ? 'bg-amber-500' :
-              a.engagementLevel >= 3 ? 'bg-green-500' :
-              a.engagementLevel >= 2 ? 'bg-blue-500' : 'bg-gray-500'
-            }`} />
-            <span className="text-[10px] text-white/60 font-mono">{a.id.slice(0, 12)}</span>
-            <span className="text-[9px] text-white/30">L{a.engagementLevel}</span>
+          <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'rgba(255,255,255,0.05)', borderRadius: '4px', paddingLeft: '6px', paddingRight: '6px', paddingTop: '2px', paddingBottom: '2px' }} title={`${a.name} — L${a.engagementLevel} ${a.priority}`}>
+            <div style={{ width: '6px', height: '6px', borderRadius: '50%', backgroundColor: a.engagementLevel >= 4 ? '#f59e0b' : a.engagementLevel >= 3 ? '#22c55e' : a.engagementLevel >= 2 ? '#3b82f6' : '#6b7280' }} />
+            <span style={{ fontSize: '10px', color: 'rgba(255,255,255,0.6)', fontFamily: 'monospace' }}>{a.id.slice(0, 12)}</span>
+            <span style={{ fontSize: '9px', color: 'rgba(255,255,255,0.3)' }}>L{a.engagementLevel}</span>
           </div>
         ))}
       </div>
-      <div className="mt-1.5 text-[10px] text-white/30">
+      <div style={{ marginTop: '6px', fontSize: '10px', color: 'rgba(255,255,255,0.3)' }}>
         {squad.agents.length} agent{squad.agents.length !== 1 ? 's' : ''} • {squad.defaultLane}
       </div>
     </div>
@@ -59,37 +52,28 @@ function SquadCard({ squad }: { squad: HubSquadInfo }) {
 function SquadHandoffRow({ handoff }: { handoff: HubSquadHandoff }) {
   const style = handoffTypeStyles[handoff.type]
   return (
-    <div className={`flex items-center gap-2 text-xs p-2 rounded border ${style.style}`}>
-      <span className="text-white/70 font-mono">{handoff.fromSquadId}</span>
-      <span className="text-white/30">{style.arrow}</span>
-      <span className="text-white/70 font-mono">{handoff.toSquadId}</span>
-      <span className="text-white/40 ml-auto text-[10px]">{handoff.type}</span>
-      <span className={`text-[10px] ${
-        handoff.status === 'active' ? 'text-green-400' :
-        handoff.status === 'pending' ? 'text-blue-400' :
-        handoff.status === 'failed' ? 'text-red-400' : 'text-white/40'
-      }`}>{handoff.status}</span>
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12px', padding: '8px', borderRadius: '4px', border: style.border }}>
+      <span style={{ color: 'rgba(255,255,255,0.7)', fontFamily: 'monospace' }}>{handoff.fromSquadId}</span>
+      <span style={ps.textFaint}>{style.arrow}</span>
+      <span style={{ color: 'rgba(255,255,255,0.7)', fontFamily: 'monospace' }}>{handoff.toSquadId}</span>
+      <span style={{ ...ps.textMuted, marginLeft: 'auto', fontSize: '10px' }}>{handoff.type}</span>
+      <span style={{ fontSize: '10px', color: handoff.status === 'active' ? '#4ade80' : handoff.status === 'pending' ? '#60a5fa' : handoff.status === 'failed' ? '#f87171' : 'rgba(255,255,255,0.4)' }}>{handoff.status}</span>
     </div>
   )
 }
 
 function RoutingRow({ decision }: { decision: HubRoutingDecision }) {
-  const modeColor = responseModeColors[decision.responseMode] || 'text-white/40'
+  const modeColor = responseModeColors[decision.responseMode] || 'rgba(255,255,255,0.4)'
   const age = `${Math.round((Date.now() - decision.timestamp) / 60000)}m`
   return (
-    <div className="flex items-center gap-2 text-[11px] py-1 border-b border-white/5 last:border-0">
-      <span className="text-white/60 font-mono truncate max-w-[80px]">{decision.agentId}</span>
-      <ArrowRight size={10} className="text-white/20" />
-      <span className="text-white/50 truncate max-w-[80px]">{decision.toolName}</span>
-      <span className={modeColor}>{decision.responseMode}</span>
-      <span className={`text-[10px] ${
-        decision.zone === 'GREEN' ? 'text-green-400' :
-        decision.zone === 'AMBER' ? 'text-amber-400' : 'text-red-400'
-      }`}>{decision.zone}</span>
-      <span className={`ml-auto text-[10px] ${decision.allowed ? 'text-green-400' : 'text-red-400'}`}>
-        {decision.allowed ? '✓' : '✗'}
-      </span>
-      <span className="text-white/20 text-[10px]">{age}</span>
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '11px', paddingTop: '4px', paddingBottom: '4px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+      <span style={{ color: 'rgba(255,255,255,0.6)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{decision.agentId}</span>
+      <ArrowRight size={10} style={{ color: 'rgba(255,255,255,0.2)' }} />
+      <span style={{ color: 'rgba(255,255,255,0.5)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '80px' }}>{decision.toolName}</span>
+      <span style={{ color: modeColor }}>{decision.responseMode}</span>
+      <span style={{ fontSize: '10px', color: decision.zone === 'GREEN' ? '#4ade80' : decision.zone === 'AMBER' ? '#fbbf24' : '#f87171' }}>{decision.zone}</span>
+      <span style={{ marginLeft: 'auto', fontSize: '10px', color: decision.allowed ? '#4ade80' : '#f87171' }}>{decision.allowed ? '✓' : '✗'}</span>
+      <span style={{ ...ps.finePrint, fontSize: '10px' }}>{age}</span>
     </div>
   )
 }
@@ -97,14 +81,14 @@ function RoutingRow({ decision }: { decision: HubRoutingDecision }) {
 export function SquadCoordinatorPanel({ data, onRefresh }: Props) {
   if (!data) {
     return (
-      <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-squad-coordinator">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+      <div style={ps.panelCard} data-testid="hub-squad-coordinator">
+        <div style={ps.panelHeaderSpaced}>
+          <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
             <Users size={14} /> Squad Coordinator
           </div>
-          <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+          <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
         </div>
-        <div className="text-white/30 text-xs text-center py-6">No squad data</div>
+        <div style={{ ...ps.loadingState, paddingTop: '24px', paddingBottom: '24px' }}>No squad data</div>
       </div>
     )
   }
@@ -112,50 +96,45 @@ export function SquadCoordinatorPanel({ data, onRefresh }: Props) {
   const { squads, recentRouting, squadHandoffs } = data
 
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10 col-span-2" data-testid="hub-squad-coordinator">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-white/80 text-sm font-medium">
+    <div style={ps.panelCard} data-testid="hub-squad-coordinator">
+      <div style={ps.panelHeaderSpaced}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 500, color: 'rgba(255,255,255,0.8)' }}>
           <Users size={14} /> Squad Coordinator
         </div>
-        <button onClick={onRefresh} className="text-white/40 hover:text-white/80 transition"><RefreshCw size={12} /></button>
+        <button type="button" onClick={onRefresh} style={ps.refreshBtn}><RefreshCw size={12} /></button>
       </div>
 
-      {/* Squad cards */}
       {squads.length > 0 && (
-        <div className="mb-4">
-          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Squads ({squads.length})</div>
-          <div className="grid grid-cols-2 gap-2">
+        <div style={{ marginBottom: '16px' }}>
+          <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '8px' }}>Squads ({squads.length})</div>
+          <div style={ps.grid2}>
             {squads.map((s) => <SquadCard key={s.squadId} squad={s} />)}
           </div>
         </div>
       )}
 
-      {/* Squad-to-Squad handoffs */}
       {squadHandoffs.length > 0 && (
-        <div className="mb-4" data-testid="hub-squad-handoffs">
-          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Squad-to-Squad ({squadHandoffs.length})</div>
-          <div className="space-y-1.5 max-h-32 overflow-y-auto">
+        <div style={{ marginBottom: '16px' }} data-testid="hub-squad-handoffs">
+          <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '8px' }}>Squad-to-Squad ({squadHandoffs.length})</div>
+          <div style={{ ...ps.stackSm, gap: '6px', maxHeight: '128px', overflowY: 'auto' }}>
             {squadHandoffs.map((h, i) => <SquadHandoffRow key={i} handoff={h} />)}
           </div>
         </div>
       )}
 
-      {/* Recent routing decisions */}
       {recentRouting.length > 0 && (
         <div data-testid="hub-routing-decisions">
-          <div className="text-[10px] text-white/40 uppercase tracking-wider mb-2">Recent Routing ({recentRouting.length})</div>
-          <div className="max-h-36 overflow-y-auto">
+          <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '8px' }}>Recent Routing ({recentRouting.length})</div>
+          <div style={{ maxHeight: '144px', overflowY: 'auto' }}>
             {recentRouting.slice(0, 10).map((d, i) => <RoutingRow key={i} decision={d} />)}
           </div>
         </div>
       )}
 
-      {/* Engagement legend */}
-      <div className="mt-3 flex items-center gap-3 text-[10px] text-white/30">
+      <div style={{ marginTop: '12px', display: 'flex', alignItems: 'center', gap: '12px', fontSize: '10px', color: 'rgba(255,255,255,0.3)' }}>
         <span>Engagement:</span>
         {[1, 2, 3, 4, 5].map((l) => (
-          <span key={l} className={dialColors[l]}>L{l} {dialLabels[l]}</span>
+          <span key={l} style={{ color: dialColors[l] }}>L{l} {dialLabels[l]}</span>
         ))}
       </div>
     </div>

--- a/src/renderer/components/dashboard/TokenActivityPanel.tsx
+++ b/src/renderer/components/dashboard/TokenActivityPanel.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import type { AuditLogEntry, HourlyBucket } from '@shared/hub-types'
 import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts'
 import { Users, Lock, Bot, User, Cpu } from 'lucide-react'
+import * as ps from './panel-styles'
 
 type Window = '1h' | '24h'
 
@@ -15,84 +16,50 @@ interface Props {
 }
 
 function ActorKindIcon({ kind }: { kind: AuditLogEntry['actorKind'] }) {
-  if (kind === 'Copilot') return <Cpu size={10} className="text-violet-400 flex-shrink-0" />
-  if (kind === 'Bot') return <Bot size={10} className="text-amber-400 flex-shrink-0" />
-  return <User size={10} className="text-blue-400 flex-shrink-0" />
+  const color = kind === 'Copilot' ? '#a78bfa' : kind === 'Bot' ? '#fbbf24' : '#60a5fa'
+  if (kind === 'Copilot') return <Cpu size={10} style={{ color, flexShrink: 0 }} />
+  if (kind === 'Bot') return <Bot size={10} style={{ color, flexShrink: 0 }} />
+  return <User size={10} style={{ color, flexShrink: 0 }} />
 }
 
 function CallerBar({ entry, max }: { entry: AuditLogEntry; max: number }) {
   const pct = max > 0 ? Math.round((entry.count / max) * 100) : 0
-  const barClass =
-    entry.actorKind === 'Copilot'
-      ? 'bg-violet-500/70'
-      : entry.actorKind === 'Bot'
-        ? 'bg-amber-500/70'
-        : 'bg-blue-500/70'
-
+  const barColor = entry.actorKind === 'Copilot' ? 'rgba(139,92,246,0.7)' : entry.actorKind === 'Bot' ? 'rgba(245,158,11,0.7)' : 'rgba(59,130,246,0.7)'
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between mb-0.5">
-          <div className="flex items-center gap-1 min-w-0">
+    <div style={{ ...ps.flexRow }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '2px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0 }}>
             <ActorKindIcon kind={entry.actorKind} />
-            <span className="text-xs font-mono text-white/80 truncate max-w-[130px]">
-              {entry.appSlug ?? entry.actor}
-            </span>
+            <span style={{ fontSize: '12px', fontFamily: 'monospace', ...ps.textPrimary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '130px' }}>{entry.appSlug ?? entry.actor}</span>
           </div>
-          <span className="text-[10px] text-white/40 tabular-nums ml-2">{entry.count}</span>
+          <span style={{ fontSize: '10px', ...ps.textMuted, fontVariantNumeric: 'tabular-nums', marginLeft: '8px' }}>{entry.count}</span>
         </div>
-        <div className="h-1 bg-white/10 rounded-full overflow-hidden">
-          <div className={`h-full rounded-full ${barClass}`} style={{ width: `${pct}%` }} />
+        <div style={ps.thinBarTrack}>
+          <div style={{ height: '100%', borderRadius: '999px', backgroundColor: barColor, width: `${pct}%` }} />
         </div>
       </div>
-      <span className="text-[9px] text-white/30 w-14 text-right flex-shrink-0">
-        {entry.tokenType}
-      </span>
+      <span style={{ fontSize: '9px', color: 'rgba(255,255,255,0.3)', width: '56px', textAlign: 'right', flexShrink: 0 }}>{entry.tokenType}</span>
     </div>
   )
 }
 
 function formatHourLabel(hourUtc: string): string {
-  // "2026-03-27 06:00Z" → "06:00"
   const match = hourUtc.match(/(\d{2}):(\d{2})Z$/)
   return match ? `${match[1]}:${match[2]}` : hourUtc
 }
 
 function HourlyChart({ buckets }: { buckets: HourlyBucket[] }) {
   if (buckets.length === 0) {
-    return (
-      <div className="h-24 flex items-center justify-center text-white/20 text-xs">
-        No hourly data yet…
-      </div>
-    )
+    return <div style={{ height: '96px', ...ps.loadingState }}>No hourly data yet…</div>
   }
-
-  const chartData = buckets.map((b) => ({
-    hour: formatHourLabel(b.hourUtc),
-    Copilot: b.copilot,
-    Human: b.human,
-    Bot: b.bot,
-  }))
-
+  const chartData = buckets.map((b) => ({ hour: formatHourLabel(b.hourUtc), Copilot: b.copilot, Human: b.human, Bot: b.bot }))
   return (
     <ResponsiveContainer width="100%" height={96}>
       <BarChart data={chartData} margin={{ top: 0, right: 0, left: -24, bottom: 0 }} barSize={6}>
-        <XAxis
-          dataKey="hour"
-          tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.3)' }}
-          tickLine={false}
-          axisLine={false}
-          interval="preserveStartEnd"
-        />
-        <Tooltip
-          contentStyle={{ background: '#1a1d23', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, fontSize: 11 }}
-          labelStyle={{ color: 'rgba(255,255,255,0.6)' }}
-          itemStyle={{ color: 'rgba(255,255,255,0.8)' }}
-        />
-        <Legend
-          iconSize={8}
-          wrapperStyle={{ fontSize: 10, paddingTop: 4 }}
-        />
+        <XAxis dataKey="hour" tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.3)' }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+        <Tooltip contentStyle={{ background: '#1a1d23', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 6, fontSize: 11 }} labelStyle={{ color: 'rgba(255,255,255,0.6)' }} itemStyle={{ color: 'rgba(255,255,255,0.8)' }} />
+        <Legend iconSize={8} wrapperStyle={{ fontSize: 10, paddingTop: 4 }} />
         <Bar dataKey="Human" stackId="a" fill="rgba(59,130,246,0.7)" radius={[0, 0, 0, 0]} />
         <Bar dataKey="Bot" stackId="a" fill="rgba(245,158,11,0.7)" radius={[0, 0, 0, 0]} />
         <Bar dataKey="Copilot" stackId="a" fill="rgba(139,92,246,0.7)" radius={[2, 2, 0, 0]} />
@@ -107,13 +74,12 @@ export function TokenActivityPanel({ topCallers, topCallers1h, hourlyBuckets, au
   if (error) {
     return (
       <Panel auditScope={auditScope} timeWindow={timeWindow} onWindowChange={setTimeWindow}>
-        <div className="flex flex-col items-center justify-center h-28 gap-2 text-white/30">
+        <div style={{ ...ps.errorState, height: '112px' }}>
           <Lock size={20} />
-          <p className="text-xs text-center">
-            Audit log error: <span className="text-white/50">{error}</span>
-            <br />
-            <span className="text-white/20 mt-1 block">
-              Requires <span className="text-white/60">read:audit_log</span> scope + enterprise admin access
+          <p style={{ ...ps.errorDetail, fontSize: '12px' }}>
+            Audit log error: <span style={ps.scopeHighlight}>{error}</span><br />
+            <span style={{ ...ps.finePrint, marginTop: '4px', display: 'block' }}>
+              Requires <span style={ps.scopeHighlight}>read:audit_log</span> scope + enterprise admin access
             </span>
           </p>
         </div>
@@ -126,80 +92,51 @@ export function TokenActivityPanel({ topCallers, topCallers1h, hourlyBuckets, au
 
   return (
     <Panel auditScope={auditScope} timeWindow={timeWindow} onWindowChange={setTimeWindow}>
-      {/* Copilot vs Human hourly stacked bar chart */}
-      <div className="mb-3">
-        <p className="text-[10px] text-white/30 mb-1">Copilot vs Human — last 24 h (hourly)</p>
+      <div style={{ marginBottom: '12px' }}>
+        <p style={{ ...ps.finePrint, marginBottom: '4px' }}>Copilot vs Human — last 24 h (hourly)</p>
         <HourlyChart buckets={hourlyBuckets} />
       </div>
 
-      {/* Per-actor ranking */}
-      <p className="text-[10px] text-white/30 mb-2">
-        Top callers — {timeWindow === '1h' ? 'last 1 h' : 'last 24 h'}
-      </p>
+      <p style={{ ...ps.finePrint, marginBottom: '8px' }}>Top callers — {timeWindow === '1h' ? 'last 1 h' : 'last 24 h'}</p>
       {callers.length === 0 ? (
-        <div className="text-white/30 text-xs text-center py-3">No API activity in this window</div>
+        <div style={{ ...ps.loadingState, paddingTop: '12px', paddingBottom: '12px' }}>No API activity in this window</div>
       ) : (
-        <div className="space-y-2">
+        <div style={ps.stackSm}>
           {callers.slice(0, 8).map((entry) => (
             <CallerBar key={entry.actor} entry={entry} max={max} />
           ))}
         </div>
       )}
 
-      {/* Legend */}
-      <div className="flex items-center gap-3 mt-3 text-[9px] text-white/30">
-        <span className="flex items-center gap-1"><Cpu size={9} className="text-violet-400" /> Copilot</span>
-        <span className="flex items-center gap-1"><User size={9} className="text-blue-400" /> Human</span>
-        <span className="flex items-center gap-1"><Bot size={9} className="text-amber-400" /> Bot</span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginTop: '12px', fontSize: '9px', color: 'rgba(255,255,255,0.3)' }}>
+        <span style={{ ...ps.flexRow, gap: '4px' }}><Cpu size={9} style={{ color: '#a78bfa' }} /> Copilot</span>
+        <span style={{ ...ps.flexRow, gap: '4px' }}><User size={9} style={{ color: '#60a5fa' }} /> Human</span>
+        <span style={{ ...ps.flexRow, gap: '4px' }}><Bot size={9} style={{ color: '#fbbf24' }} /> Bot</span>
       </div>
     </Panel>
   )
 }
 
-function Panel({
-  children,
-  auditScope,
-  timeWindow,
-  onWindowChange,
-}: {
-  children: React.ReactNode
-  auditScope: 'enterprise' | 'org' | null
-  timeWindow: Window
-  onWindowChange: (w: Window) => void
-}) {
+function Panel({ children, auditScope, timeWindow, onWindowChange }: { children: React.ReactNode; auditScope: 'enterprise' | 'org' | null; timeWindow: Window; onWindowChange: (w: Window) => void }) {
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
-          <Users size={14} />
-          Token Activity
+    <div style={ps.panelCard}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px' }}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 600, color: 'rgba(255,255,255,0.8)' }}>
+          <Users size={14} /> Token Activity
           {auditScope === 'org' && (
-            <span className="text-[9px] font-normal text-amber-400/70 border border-amber-400/30 rounded px-1 py-0.5">
-              org scope
-            </span>
+            <span style={{ fontSize: '9px', fontWeight: 400, color: 'rgba(251,191,36,0.7)', border: '1px solid rgba(251,191,36,0.3)', borderRadius: '4px', paddingLeft: '4px', paddingRight: '4px', paddingTop: '2px', paddingBottom: '2px' }}>org scope</span>
           )}
         </div>
-        <div className="flex items-center gap-1">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           {(['1h', '24h'] as Window[]).map((w) => (
-            <button
-              key={w}
-              onClick={() => onWindowChange(w)}
-              className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
-                timeWindow === w
-                  ? 'bg-white/15 text-white/90'
-                  : 'text-white/30 hover:text-white/60'
-              }`}
-            >
-              {w}
-            </button>
+            <button key={w} type="button" onClick={() => onWindowChange(w)} style={timeWindow === w ? ps.tabActive : ps.tabInactive}>{w}</button>
           ))}
         </div>
       </div>
       {children}
       {auditScope === 'org' && (
-        <p className="text-[9px] text-white/20 mt-2 border-t border-white/5 pt-2">
-          Using org-level audit log · add{' '}
-          <span className="text-white/40">admin:enterprise</span> scope for full enterprise view
+        <p style={{ ...ps.finePrint, marginTop: '8px', borderTop: '1px solid rgba(255,255,255,0.05)', paddingTop: '8px' }}>
+          Using org-level audit log · add <span style={ps.textMuted}>admin:enterprise</span> scope for full enterprise view
         </p>
       )}
     </div>

--- a/src/renderer/components/dashboard/TokenAuthPanel.tsx
+++ b/src/renderer/components/dashboard/TokenAuthPanel.tsx
@@ -1,20 +1,13 @@
 // TokenAuthPanel.tsx — GitHub OAuth-only sign-in for enterprise dashboard access.
-// Spawns "gh auth login --web" silently, captures the device code, and shows it
-// inline so the user never needs a hidden terminal window.
 import { useState, useEffect, useRef } from 'react'
 import { CheckCircle, AlertCircle, LogIn, RefreshCw, LogOut, Loader2, Copy, Check } from 'lucide-react'
+import * as ps from './panel-styles'
 
 interface AuthConfig {
-  enterprise: string
-  org: string
-  ghAuthenticated: boolean
-  ghScopes: string[]
-  missingScopes: string[]
+  enterprise: string; org: string; ghAuthenticated: boolean; ghScopes: string[]; missingScopes: string[]
 }
 
-interface Props {
-  onSaved?: () => void
-}
+interface Props { onSaved?: () => void }
 
 const REQUIRED_SCOPES = [
   { scope: 'read:audit_log', panel: 'Token Activity', required: true },
@@ -23,6 +16,22 @@ const REQUIRED_SCOPES = [
 ]
 
 const POLL_INTERVAL_MS = 2500
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: '8px', paddingLeft: '12px', paddingRight: '12px', paddingTop: '6px', paddingBottom: '6px',
+  fontSize: '13px', color: 'rgba(255,255,255,0.8)', outline: 'none',
+}
+
+const primaryBtn: React.CSSProperties = {
+  paddingTop: '6px', paddingBottom: '6px', borderRadius: '8px', fontSize: '12px', fontWeight: 500,
+  background: '#2563eb', color: '#fff', border: 'none', cursor: 'pointer', display: 'flex',
+  alignItems: 'center', justifyContent: 'center', gap: '6px', transition: 'background 150ms',
+}
+
+const secondaryBtn: React.CSSProperties = {
+  ...primaryBtn, background: 'rgba(255,255,255,0.1)', color: '#fff',
+}
 
 export function TokenAuthPanel({ onSaved }: Props) {
   const [config, setConfig] = useState<AuthConfig | null>(null)
@@ -37,271 +46,135 @@ export function TokenAuthPanel({ onSaved }: Props) {
 
   async function loadConfig() {
     const cfg = await window.hubAPI.getTokenConfig()
-    setConfig(cfg)
-    setEnterprise(cfg.enterprise)
-    setOrg(cfg.org)
+    setConfig(cfg); setEnterprise(cfg.enterprise); setOrg(cfg.org)
   }
 
   useEffect(() => {
     void loadConfig()
-    // Listen for device code from main process
-    const unsubCode = window.hubAPI.onDeviceCode((code: string) => {
-      setDeviceCode(code)
-      setCopied(false)
-    })
-    return () => {
-      if (pollRef.current) clearTimeout(pollRef.current)
-      unsubCode()
-    }
+    const unsubCode = window.hubAPI.onDeviceCode((code: string) => { setDeviceCode(code); setCopied(false) })
+    return () => { if (pollRef.current) clearTimeout(pollRef.current); unsubCode() }
   }, [])
 
-  function stopPolling() {
-    if (pollRef.current) {
-      clearTimeout(pollRef.current)
-      pollRef.current = null
-    }
-    setPolling(false)
-  }
+  function stopPolling() { if (pollRef.current) { clearTimeout(pollRef.current); pollRef.current = null }; setPolling(false) }
 
   function startPolling(ent: string, orgSlug: string) {
     setPolling(true)
     setMessage({ type: 'info', text: 'Paste the code below into your browser and authorize. Waiting…' })
-
     async function poll() {
       try {
         const status = await window.hubAPI.checkLoginStatus()
-        if (!status.authenticated) {
-          // Schedule next poll only after this one completes — prevents overlapping IPC calls
-          pollRef.current = setTimeout(poll, POLL_INTERVAL_MS)
-          return
-        }
-
-        stopPolling()
-        setDeviceCode(null)
-
-        if (status.missingScopes.length > 0) {
-          setMessage({
-            type: 'error',
-            text: `Signed in, but missing: ${status.missingScopes.join(', ')}. Re-authorize and grant all required scopes.`,
-          })
-        } else {
-          // Complete the login — starts the monitor service
-          await window.hubAPI.completeGitHubLogin({ enterprise: ent, org: orgSlug })
-          setMessage({ type: 'success', text: 'Signed in with GitHub — enterprise panels are now unlocked.' })
-          onSaved?.()
-        }
+        if (!status.authenticated) { pollRef.current = setTimeout(poll, POLL_INTERVAL_MS); return }
+        stopPolling(); setDeviceCode(null)
+        if (status.missingScopes.length > 0) { setMessage({ type: 'error', text: `Signed in, but missing: ${status.missingScopes.join(', ')}. Re-authorize and grant all required scopes.` }) }
+        else { await window.hubAPI.completeGitHubLogin({ enterprise: ent, org: orgSlug }); setMessage({ type: 'success', text: 'Signed in with GitHub — enterprise panels are now unlocked.' }); onSaved?.() }
         await loadConfig()
-      } catch (err) {
-        // Transient error — log and reschedule so polling continues
-        console.error('[TokenAuthPanel] Poll error:', err)
-        pollRef.current = setTimeout(poll, POLL_INTERVAL_MS)
-      }
+      } catch (err) { console.error('[TokenAuthPanel] Poll error:', err); pollRef.current = setTimeout(poll, POLL_INTERVAL_MS) }
     }
     pollRef.current = setTimeout(poll, POLL_INTERVAL_MS)
   }
 
   async function handleSignIn() {
-    stopPolling()
-    setBusy(true)
-    setMessage(null)
-    setDeviceCode(null)
-
-    const ent = enterprise.trim() || 'AICraftworks'
-    const orgSlug = org.trim() || 'AgentCraftworks'
+    stopPolling(); setBusy(true); setMessage(null); setDeviceCode(null)
+    const ent = enterprise.trim() || 'AICraftworks'; const orgSlug = org.trim() || 'AgentCraftworks'
     const result = await window.hubAPI.beginGitHubLogin({ enterprise: ent, org: orgSlug })
     setBusy(false)
-
-    if (!result.ok) {
-      setMessage({ type: 'error', text: result.error ?? 'Unable to start GitHub login. Is gh CLI installed?' })
-      return
-    }
-
+    if (!result.ok) { setMessage({ type: 'error', text: result.error ?? 'Unable to start GitHub login. Is gh CLI installed?' }); return }
     startPolling(ent, orgSlug)
   }
 
   async function handleVerify() {
-    stopPolling()
-    setBusy(true)
-    setMessage(null)
+    stopPolling(); setBusy(true); setMessage(null)
     const result = await window.hubAPI.completeGitHubLogin({ enterprise: enterprise.trim(), org: org.trim() })
     setBusy(false)
-
-    if (!result.ok) {
-      setMessage({ type: 'error', text: result.error ?? 'GitHub sign-in verification failed.' })
-      return
-    }
-    if ((result.missingScopes?.length ?? 0) > 0) {
-      setMessage({
-        type: 'error',
-        text: `Signed in, but missing scopes: ${result.missingScopes?.join(', ')}.`,
-      })
-    } else {
-      setMessage({ type: 'success', text: 'Signed in — enterprise panels unlocked.' })
-      onSaved?.()
-    }
+    if (!result.ok) { setMessage({ type: 'error', text: result.error ?? 'GitHub sign-in verification failed.' }); return }
+    if ((result.missingScopes?.length ?? 0) > 0) { setMessage({ type: 'error', text: `Signed in, but missing scopes: ${result.missingScopes?.join(', ')}.` }) }
+    else { setMessage({ type: 'success', text: 'Signed in — enterprise panels unlocked.' }); onSaved?.() }
     await loadConfig()
   }
 
   async function handleSignOut() {
-    stopPolling()
-    setBusy(true)
-    setMessage(null)
-    setDeviceCode(null)
-    await window.hubAPI.logoutGitHub()
-    setBusy(false)
-    await loadConfig()
+    stopPolling(); setBusy(true); setMessage(null); setDeviceCode(null)
+    await window.hubAPI.logoutGitHub(); setBusy(false); await loadConfig()
     setMessage({ type: 'success', text: 'Signed out from GitHub.' })
   }
 
   const allScopesGranted = config?.ghAuthenticated && config.missingScopes.length === 0
 
   return (
-    <div className="bg-white/5 rounded-xl p-4 border border-white/10 space-y-4">
-      <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" className="opacity-70">
+    <div style={{ ...ps.panelCard, ...ps.stackSm, gap: '16px' }}>
+      <div style={ps.panelHeader}>
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style={{ opacity: 0.7 }}>
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
         </svg>
         GitHub Authentication
       </div>
 
-      {/* Status badge */}
       {config && (
-        <div className={`flex items-center gap-2 text-xs px-3 py-2 rounded-lg ${
-          allScopesGranted
-            ? 'bg-green-500/10 text-green-400'
-            : 'bg-amber-500/10 text-amber-400'
-        }`}>
-          {allScopesGranted
-            ? <><CheckCircle size={12} /> Signed in with GitHub — all enterprise panels unlocked</>
-            : config.ghAuthenticated
-              ? <><AlertCircle size={12} /> Signed in, but missing required scopes</>
-              : <><AlertCircle size={12} /> Not signed in to GitHub</>
-          }
+        <div style={{ ...ps.flexRow, fontSize: '12px', paddingLeft: '12px', paddingRight: '12px', paddingTop: '8px', paddingBottom: '8px', borderRadius: '8px', background: allScopesGranted ? 'rgba(34,197,94,0.1)' : 'rgba(245,158,11,0.1)', color: allScopesGranted ? '#4ade80' : '#fbbf24' }}>
+          {allScopesGranted ? <><CheckCircle size={12} /> Signed in with GitHub — all enterprise panels unlocked</> : config.ghAuthenticated ? <><AlertCircle size={12} /> Signed in, but missing required scopes</> : <><AlertCircle size={12} /> Not signed in to GitHub</>}
         </div>
       )}
 
-      {/* Required scopes */}
-      <div className="text-xs text-white/40 space-y-1.5">
-        <div className="text-white/60 font-medium">Required scopes to unlock enterprise panels:</div>
+      <div style={{ fontSize: '12px', color: 'rgba(255,255,255,0.4)', ...ps.stackSm, gap: '6px' }}>
+        <div style={{ color: 'rgba(255,255,255,0.6)', fontWeight: 500 }}>Required scopes to unlock enterprise panels:</div>
         {REQUIRED_SCOPES.map(({ scope, panel }) => {
           const granted = config?.ghScopes.includes(scope)
           return (
-            <div key={scope} className="flex items-center gap-2">
-              {granted
-                ? <CheckCircle size={10} className="text-green-400 shrink-0" />
-                : <AlertCircle size={10} className="text-amber-400/60 shrink-0" />
-              }
-              <code className="bg-white/5 px-1.5 py-0.5 rounded text-purple-300 font-mono">{scope}</code>
-              <span className="text-white/30">→ {panel}</span>
+            <div key={scope} style={ps.flexRow}>
+              {granted ? <CheckCircle size={10} style={{ color: '#4ade80', flexShrink: 0 }} /> : <AlertCircle size={10} style={{ color: 'rgba(251,191,36,0.6)', flexShrink: 0 }} />}
+              <code style={{ background: 'rgba(255,255,255,0.05)', paddingLeft: '6px', paddingRight: '6px', paddingTop: '2px', paddingBottom: '2px', borderRadius: '4px', color: '#c084fc', fontFamily: 'monospace' }}>{scope}</code>
+              <span style={ps.textFaint}>→ {panel}</span>
             </div>
           )
         })}
-        <p className="text-white/25 pt-1">
-          Auth uses GitHub CLI (<code className="text-white/40">gh auth login</code>) — no PAT entry required.
-          Your browser will open automatically.
-        </p>
+        <p style={{ ...ps.finePrint, paddingTop: '4px' }}>Auth uses GitHub CLI (<code style={ps.textMuted}>gh auth login</code>) — no PAT entry required.</p>
       </div>
 
-      {/* Enterprise & Org slugs — side by side */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '12px' }}>
         <div>
-          <label className="text-[10px] text-white/40 uppercase tracking-wide block mb-1">Enterprise slug</label>
-          <input
-            type="text"
-            value={enterprise}
-            onChange={e => setEnterprise(e.target.value)}
-            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white/80 focus:outline-none focus:border-blue-500/50"
-            placeholder="AICraftworks"
-          />
-          <p className="text-[10px] text-white/25 mt-1">Used for audit log (enterprise API)</p>
+          <label style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', display: 'block', marginBottom: '4px' }}>Enterprise slug</label>
+          <input type="text" value={enterprise} onChange={e => setEnterprise(e.target.value)} style={inputStyle} placeholder="AICraftworks" />
+          <p style={{ ...ps.finePrint, marginTop: '4px' }}>Used for audit log (enterprise API)</p>
         </div>
         <div>
-          <label className="text-[10px] text-white/40 uppercase tracking-wide block mb-1">Org slug</label>
-          <input
-            type="text"
-            value={org}
-            onChange={e => setOrg(e.target.value)}
-            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white/80 focus:outline-none focus:border-blue-500/50"
-            placeholder="AgentCraftworks"
-          />
-          <p className="text-[10px] text-white/25 mt-1">Used for billing &amp; Copilot (org API)</p>
+          <label style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.05em', display: 'block', marginBottom: '4px' }}>Org slug</label>
+          <input type="text" value={org} onChange={e => setOrg(e.target.value)} style={inputStyle} placeholder="AgentCraftworks" />
+          <p style={{ ...ps.finePrint, marginTop: '4px' }}>Used for billing &amp; Copilot (org API)</p>
         </div>
       </div>
 
-      {/* Action buttons */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-        <button
-          onClick={handleSignIn}
-          disabled={busy || polling}
-          className="py-1.5 rounded-lg text-xs font-medium bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-white flex items-center justify-center gap-1.5"
-        >
-          {polling ? <Loader2 size={12} className="animate-spin" /> : <LogIn size={12} />}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
+        <button type="button" onClick={handleSignIn} disabled={busy || polling} style={{ ...primaryBtn, opacity: (busy || polling) ? 0.4 : 1 }}>
+          {polling ? <Loader2 size={12} style={{ animation: 'spin 1s linear infinite' }} /> : <LogIn size={12} />}
           {polling ? 'Waiting…' : 'Sign in with GitHub'}
         </button>
-        <button
-          onClick={handleVerify}
-          disabled={busy || polling}
-          className="py-1.5 rounded-lg text-xs font-medium bg-white/10 hover:bg-white/15 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-white flex items-center justify-center gap-1.5"
-        >
+        <button type="button" onClick={handleVerify} disabled={busy || polling} style={{ ...secondaryBtn, opacity: (busy || polling) ? 0.4 : 1 }}>
           <RefreshCw size={12} /> Verify Login
         </button>
-        <button
-          onClick={handleSignOut}
-          disabled={busy || polling}
-          className="py-1.5 rounded-lg text-xs font-medium bg-white/10 hover:bg-white/15 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-white flex items-center justify-center gap-1.5"
-        >
+        <button type="button" onClick={handleSignOut} disabled={busy || polling} style={{ ...secondaryBtn, opacity: (busy || polling) ? 0.4 : 1 }}>
           <LogOut size={12} /> Sign Out
         </button>
       </div>
 
-      {/* Device code display — shown during OAuth device flow */}
       {deviceCode && (
-        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 space-y-2">
-          <div className="text-xs text-blue-300 font-medium">
-            Enter this code on GitHub to authorize:
-          </div>
-          <div className="flex items-center gap-3">
-            <code className="text-2xl font-bold font-mono text-white tracking-[0.2em] select-all">
-              {deviceCode}
-            </code>
-            <button
-              onClick={() => {
-                navigator.clipboard.writeText(deviceCode)
-                setCopied(true)
-                setTimeout(() => setCopied(false), 2000)
-              }}
-              className="px-2 py-1 rounded text-xs bg-white/10 hover:bg-white/20 transition-colors text-white/70 flex items-center gap-1"
-            >
-              {copied ? <><Check size={10} className="text-green-400" /> Copied</> : <><Copy size={10} /> Copy</>}
+        <div style={{ background: 'rgba(59,130,246,0.1)', border: '1px solid rgba(59,130,246,0.2)', borderRadius: '8px', padding: '12px', ...ps.stackSm }}>
+          <div style={{ fontSize: '12px', color: '#93c5fd', fontWeight: 500 }}>Enter this code on GitHub to authorize:</div>
+          <div style={ps.flexRow}>
+            <code style={{ fontSize: '24px', fontWeight: 700, fontFamily: 'monospace', color: '#fff', letterSpacing: '0.2em', userSelect: 'all' }}>{deviceCode}</code>
+            <button type="button" onClick={() => { navigator.clipboard.writeText(deviceCode); setCopied(true); setTimeout(() => setCopied(false), 2000) }} style={{ ...secondaryBtn, paddingLeft: '8px', paddingRight: '8px', paddingTop: '4px', paddingBottom: '4px', fontSize: '12px' }}>
+              {copied ? <><Check size={10} style={{ color: '#4ade80' }} /> Copied</> : <><Copy size={10} /> Copy</>}
             </button>
           </div>
-          <div className="text-[10px] text-blue-300/60">
+          <div style={{ fontSize: '10px', color: 'rgba(147,197,253,0.6)' }}>
             Your browser should open automatically. If not,{' '}
-            <button
-              onClick={() => window.hubAPI.openDevicePage()}
-              className="underline hover:text-blue-300 transition-colors"
-            >
-              click here to open github.com/login/device
-            </button>
+            <button type="button" onClick={() => window.hubAPI.openDevicePage()} style={{ textDecoration: 'underline', background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: 0, font: 'inherit', fontSize: 'inherit' }}>click here to open github.com/login/device</button>
           </div>
         </div>
       )}
 
-      {/* Feedback */}
       {message && (
-        <div className={`text-xs px-3 py-2 rounded-lg flex items-center gap-2 ${
-          message.type === 'success'
-            ? 'bg-green-500/10 text-green-400'
-            : message.type === 'info'
-              ? 'bg-blue-500/10 text-blue-300'
-              : 'bg-red-500/10 text-red-400'
-        }`}>
-          {message.type === 'success'
-            ? <CheckCircle size={12} />
-            : message.type === 'info'
-              ? <Loader2 size={12} className="animate-spin" />
-              : <AlertCircle size={12} />
-          }
+        <div style={{ ...ps.flexRow, fontSize: '12px', paddingLeft: '12px', paddingRight: '12px', paddingTop: '8px', paddingBottom: '8px', borderRadius: '8px', background: message.type === 'success' ? 'rgba(34,197,94,0.1)' : message.type === 'info' ? 'rgba(59,130,246,0.1)' : 'rgba(239,68,68,0.1)', color: message.type === 'success' ? '#4ade80' : message.type === 'info' ? '#93c5fd' : '#f87171' }}>
+          {message.type === 'success' ? <CheckCircle size={12} /> : message.type === 'info' ? <Loader2 size={12} style={{ animation: 'spin 1s linear infinite' }} /> : <AlertCircle size={12} />}
           {message.text}
         </div>
       )}

--- a/src/renderer/components/dashboard/WorkflowHealthPanel.tsx
+++ b/src/renderer/components/dashboard/WorkflowHealthPanel.tsx
@@ -1,15 +1,8 @@
 import { useMemo } from 'react'
 import type { ActionRequest, OperationLogEntry } from '@shared/hub-types'
 import { Activity, AlertTriangle, CheckCircle2, RefreshCw } from 'lucide-react'
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import * as ps from './panel-styles'
 
 interface Props {
   entries: OperationLogEntry[]
@@ -21,226 +14,106 @@ interface Props {
 type WorkflowHealthStatus = 'healthy' | 'degraded' | 'critical' | 'stale' | 'no-data'
 
 export interface WorkflowHealthMetrics {
-  status: WorkflowHealthStatus
-  successfulRuns: number
-  failedRuns: number
-  totalRuns: number
-  successRate: number
-  pendingRequests: number
-  chart: Array<{ hour: string; total: number; failed: number }>
+  status: WorkflowHealthStatus; successfulRuns: number; failedRuns: number; totalRuns: number
+  successRate: number; pendingRequests: number; chart: Array<{ hour: string; total: number; failed: number }>
 }
 
 const STALE_WINDOW_MS = 5 * 60_000
 const CRITICAL_FAILURE_COUNT = 3
 const CRITICAL_FAILURE_RATIO = 0.3
 const CRITICAL_PENDING_REQUESTS = 10
-const TOOLTIP_LABELS: Record<string, string> = {
-  failed: 'Failed',
-  total: 'Total',
-}
+const TOOLTIP_LABELS: Record<string, string> = { failed: 'Failed', total: 'Total' }
 
-export function buildWorkflowHealthMetrics(
-  entries: OperationLogEntry[],
-  actionRequests: ActionRequest[],
-  now = Date.now(),
-  lastUpdated: Date | null = null,
-): WorkflowHealthMetrics {
-  const pendingRequests = actionRequests.filter((request) => request.state === 'pending').length
+export function buildWorkflowHealthMetrics(entries: OperationLogEntry[], actionRequests: ActionRequest[], now = Date.now(), lastUpdated: Date | null = null): WorkflowHealthMetrics {
+  const pendingRequests = actionRequests.filter((r) => r.state === 'pending').length
   const last24hStart = now - 24 * 60 * 60_000
-
-  const recentRuns = entries.filter((entry) => {
-    const ts = Date.parse(entry.ts)
-    return Number.isFinite(ts) && ts >= last24hStart
-  })
-
-  const successfulRuns = recentRuns.filter((entry) => entry.result === 'ok').length
-  const failedRuns = recentRuns.filter((entry) => entry.result === 'failed').length
+  const recentRuns = entries.filter((e) => { const ts = Date.parse(e.ts); return Number.isFinite(ts) && ts >= last24hStart })
+  const successfulRuns = recentRuns.filter((e) => e.result === 'ok').length
+  const failedRuns = recentRuns.filter((e) => e.result === 'failed').length
   const totalRuns = successfulRuns + failedRuns
   const successRate = totalRuns > 0 ? Math.round((successfulRuns / totalRuns) * 100) : 0
 
   const chartBuckets = new Map<string, { total: number; failed: number }>()
-  for (let i = 5; i >= 0; i--) {
-    const point = new Date(now - i * 60 * 60_000)
-    const key = `${point.getHours().toString().padStart(2, '0')}:00`
-    chartBuckets.set(key, { total: 0, failed: 0 })
-  }
-
-  for (const entry of recentRuns) {
-    const ts = Date.parse(entry.ts)
-    if (!Number.isFinite(ts) || ts < now - 6 * 60 * 60_000) {
-      continue
-    }
-
-    const point = new Date(ts)
-    const key = `${point.getHours().toString().padStart(2, '0')}:00`
-    const bucket = chartBuckets.get(key)
-    if (!bucket) {
-      continue
-    }
-
-    if (entry.result === 'ok' || entry.result === 'failed') {
-      bucket.total += 1
-      if (entry.result === 'failed') {
-        bucket.failed += 1
-      }
-    }
-  }
-
-  const chart = Array.from(chartBuckets.entries()).map(([hour, value]) => ({
-    hour,
-    total: value.total,
-    failed: value.failed,
-  }))
+  for (let i = 5; i >= 0; i--) { const p = new Date(now - i * 60 * 60_000); chartBuckets.set(`${p.getHours().toString().padStart(2, '0')}:00`, { total: 0, failed: 0 }) }
+  for (const e of recentRuns) { const ts = Date.parse(e.ts); if (!Number.isFinite(ts) || ts < now - 6 * 60 * 60_000) continue; const p = new Date(ts); const key = `${p.getHours().toString().padStart(2, '0')}:00`; const b = chartBuckets.get(key); if (!b) continue; if (e.result === 'ok' || e.result === 'failed') { b.total += 1; if (e.result === 'failed') b.failed += 1 } }
+  const chart = Array.from(chartBuckets.entries()).map(([hour, v]) => ({ hour, total: v.total, failed: v.failed }))
 
   let status: WorkflowHealthStatus = 'healthy'
+  if (!lastUpdated || now - lastUpdated.getTime() > STALE_WINDOW_MS) status = 'stale'
+  else if (totalRuns === 0 && pendingRequests === 0) status = 'no-data'
+  else if (failedRuns >= CRITICAL_FAILURE_COUNT || (totalRuns > 0 && (failedRuns / totalRuns) >= CRITICAL_FAILURE_RATIO) || pendingRequests >= CRITICAL_PENDING_REQUESTS) status = 'critical'
+  else if (failedRuns > 0 || pendingRequests > 0) status = 'degraded'
 
-  if (!lastUpdated || now - lastUpdated.getTime() > STALE_WINDOW_MS) {
-    status = 'stale'
-  } else if (totalRuns === 0 && pendingRequests === 0) {
-    status = 'no-data'
-  } else if (
-    failedRuns >= CRITICAL_FAILURE_COUNT
-    || (totalRuns > 0 && (failedRuns / totalRuns) >= CRITICAL_FAILURE_RATIO)
-    || pendingRequests >= CRITICAL_PENDING_REQUESTS
-  ) {
-    status = 'critical'
-  } else if (failedRuns > 0 || pendingRequests > 0) {
-    status = 'degraded'
-  }
-
-  return {
-    status,
-    successfulRuns,
-    failedRuns,
-    totalRuns,
-    successRate,
-    pendingRequests,
-    chart,
-  }
+  return { status, successfulRuns, failedRuns, totalRuns, successRate, pendingRequests, chart }
 }
 
+const statusTheme = {
+  healthy: { text: 'Healthy', bg: 'rgba(16,185,129,0.15)', color: '#6ee7b7' },
+  degraded: { text: 'Degraded', bg: 'rgba(245,158,11,0.15)', color: '#fcd34d' },
+  critical: { text: 'Critical', bg: 'rgba(239,68,68,0.15)', color: '#fca5a5' },
+  stale: { text: 'Stale', bg: 'rgba(100,116,139,0.2)', color: '#cbd5e1' },
+  'no-data': { text: 'Waiting for data', bg: 'rgba(100,116,139,0.2)', color: '#cbd5e1' },
+} as const
+
 export function WorkflowHealthPanel({ entries, actionRequests, lastUpdated, onRefresh }: Props) {
-  const metrics = useMemo(
-    () => buildWorkflowHealthMetrics(entries, actionRequests, Date.now(), lastUpdated),
-    [entries, actionRequests, lastUpdated],
-  )
-
-  const statusTheme = {
-    healthy: { text: 'Healthy', className: 'text-emerald-300 bg-emerald-500/15' },
-    degraded: { text: 'Degraded', className: 'text-amber-300 bg-amber-500/15' },
-    critical: { text: 'Critical', className: 'text-red-300 bg-red-500/15' },
-    stale: { text: 'Stale', className: 'text-slate-300 bg-slate-500/20' },
-    'no-data': { text: 'Waiting for data', className: 'text-slate-300 bg-slate-500/20' },
-  } as const
-
-  const activeTheme = statusTheme[metrics.status]
+  const metrics = useMemo(() => buildWorkflowHealthMetrics(entries, actionRequests, Date.now(), lastUpdated), [entries, actionRequests, lastUpdated])
+  const active = statusTheme[metrics.status]
 
   return (
     <PanelShell title="Workflow Health" icon={<Activity size={14} />} onRefresh={onRefresh}>
-      <div className="flex items-center justify-between mb-3">
-        <div className="text-xs text-white/50">Last 24h workflow outcomes</div>
-        <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${activeTheme.className}`}>
-          {activeTheme.text}
-        </span>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px' }}>
+        <div style={{ fontSize: '12px', color: 'rgba(255,255,255,0.5)' }}>Last 24h workflow outcomes</div>
+        <span style={{ fontSize: '10px', paddingLeft: '8px', paddingRight: '8px', paddingTop: '2px', paddingBottom: '2px', borderRadius: '999px', fontWeight: 500, background: active.bg, color: active.color }}>{active.text}</span>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-3">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '8px', marginBottom: '12px' }}>
         <StatCard label="Total runs" value={metrics.totalRuns.toString()} />
         <StatCard label="Success rate" value={`${metrics.successRate}%`} />
         <StatCard label="Failures" value={metrics.failedRuns.toString()} tone="danger" />
         <StatCard label="Pending approvals" value={metrics.pendingRequests.toString()} tone="warn" />
       </div>
 
-      <div className="h-28">
+      <div style={{ height: '112px' }}>
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={metrics.chart} margin={{ top: 5, right: 6, left: -20, bottom: 0 }}>
             <defs>
-              <linearGradient id="workflowTotal" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.35} />
-                <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.04} />
-              </linearGradient>
-              <linearGradient id="workflowFailed" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
-              </linearGradient>
+              <linearGradient id="workflowTotal" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#3b82f6" stopOpacity={0.35} /><stop offset="95%" stopColor="#3b82f6" stopOpacity={0.04} /></linearGradient>
+              <linearGradient id="workflowFailed" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} /><stop offset="95%" stopColor="#ef4444" stopOpacity={0} /></linearGradient>
             </defs>
             <CartesianGrid stroke="rgba(255,255,255,0.08)" vertical={false} />
-            <XAxis
-              dataKey="hour"
-              tick={{ fill: 'rgba(255,255,255,0.35)', fontSize: 9 }}
-              tickLine={false}
-              axisLine={false}
-            />
-            <YAxis
-              allowDecimals={false}
-              tick={{ fill: 'rgba(255,255,255,0.2)', fontSize: 9 }}
-              tickLine={false}
-              axisLine={false}
-              width={24}
-            />
-            <Tooltip
-              contentStyle={{ background: '#111827', border: 'none', borderRadius: 6, fontSize: 11 }}
-              formatter={(value: number, name: string) => [value.toLocaleString(), TOOLTIP_LABELS[name] ?? name]}
-            />
+            <XAxis dataKey="hour" tick={{ fill: 'rgba(255,255,255,0.35)', fontSize: 9 }} tickLine={false} axisLine={false} />
+            <YAxis allowDecimals={false} tick={{ fill: 'rgba(255,255,255,0.2)', fontSize: 9 }} tickLine={false} axisLine={false} width={24} />
+            <Tooltip contentStyle={{ background: '#111827', border: 'none', borderRadius: 6, fontSize: 11 }} formatter={(value: number, name: string) => [value.toLocaleString(), TOOLTIP_LABELS[name] ?? name]} />
             <Area type="monotone" dataKey="total" stroke="#3b82f6" strokeWidth={1.5} fill="url(#workflowTotal)" />
             <Area type="monotone" dataKey="failed" stroke="#ef4444" strokeWidth={1.3} fill="url(#workflowFailed)" />
           </AreaChart>
         </ResponsiveContainer>
       </div>
 
-      <div className="mt-2 text-[10px] text-white/25 flex items-center gap-1">
-        {metrics.status === 'critical'
-          ? <AlertTriangle size={10} className="text-red-300/80" />
-          : <CheckCircle2 size={10} className="text-emerald-300/80" />}
+      <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '4px', ...ps.finePrint }}>
+        {metrics.status === 'critical' ? <AlertTriangle size={10} style={{ color: 'rgba(252,165,165,0.8)' }} /> : <CheckCircle2 size={10} style={{ color: 'rgba(110,231,183,0.8)' }} />}
         Real-time status updates from operation and request streams
       </div>
     </PanelShell>
   )
 }
 
-function StatCard({
-  label,
-  value,
-  tone = 'default',
-}: {
-  label: string
-  value: string
-  tone?: 'default' | 'warn' | 'danger'
-}) {
-  const toneClass = tone === 'danger'
-    ? 'text-red-300'
-    : tone === 'warn'
-      ? 'text-amber-300'
-      : 'text-white'
+function StatCard({ label, value, tone = 'default' }: { label: string; value: string; tone?: 'default' | 'warn' | 'danger' }) {
+  const color = tone === 'danger' ? '#fca5a5' : tone === 'warn' ? '#fcd34d' : '#fff'
   return (
-    <div className="rounded-md border border-white/10 bg-black/20 px-2 py-1.5">
-      <div className="text-[10px] text-white/45">{label}</div>
-      <div className={`text-sm font-semibold tabular-nums ${toneClass}`}>{value}</div>
+    <div style={{ borderRadius: '6px', border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(0,0,0,0.2)', paddingLeft: '8px', paddingRight: '8px', paddingTop: '6px', paddingBottom: '6px' }}>
+      <div style={{ fontSize: '10px', color: 'rgba(255,255,255,0.45)' }}>{label}</div>
+      <div style={{ fontSize: '13px', fontWeight: 600, fontVariantNumeric: 'tabular-nums', color }}>{value}</div>
     </div>
   )
 }
 
-function PanelShell({
-  title,
-  icon,
-  onRefresh,
-  children,
-}: {
-  title: string
-  icon: React.ReactNode
-  onRefresh: () => void
-  children: React.ReactNode
-}) {
+function PanelShell({ title, icon, onRefresh, children }: { title: string; icon: React.ReactNode; onRefresh: () => void; children: React.ReactNode }) {
   return (
-    <div className="bg-white/5 rounded-xl p-4 flex flex-col gap-1 border border-white/10">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
-          {icon}
-          {title}
-        </div>
-        <button onClick={onRefresh} className="text-white/30 hover:text-white/70 transition-colors">
-          <RefreshCw size={12} />
-        </button>
+    <div style={ps.panelCardFlex}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+        <div style={{ ...ps.flexRow, fontSize: '13px', fontWeight: 600, color: 'rgba(255,255,255,0.8)' }}>{icon}{title}</div>
+        <button type="button" onClick={onRefresh} style={ps.refreshBtn} title="Refresh"><RefreshCw size={12} /></button>
       </div>
       {children}
     </div>

--- a/src/renderer/components/dashboard/panel-styles.ts
+++ b/src/renderer/components/dashboard/panel-styles.ts
@@ -1,0 +1,218 @@
+/**
+ * Shared inline style constants for dashboard panels.
+ *
+ * These replace the common Tailwind utility classes used across all panels.
+ * Using plain style objects instead of makeStyles because Griffel's strict
+ * typing rejects CSS custom properties and rgba() values in many contexts.
+ */
+import type { CSSProperties } from 'react'
+
+/** Panel outer container — replaces `bg-white/5 rounded-xl p-4 border border-white/10` */
+export const panelCard: CSSProperties = {
+  background: 'rgba(255,255,255,0.05)',
+  borderRadius: '12px',
+  padding: '16px',
+  border: '1px solid rgba(255,255,255,0.1)',
+}
+
+/** Panel card with flex column — same as panelCard + `flex flex-col gap-1` */
+export const panelCardFlex: CSSProperties = {
+  ...panelCard,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+}
+
+/** Panel header row — replaces `flex items-center gap-2 text-sm font-semibold text-white/80 mb-3` */
+export const panelHeader: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: '13px',
+  fontWeight: 600,
+  color: 'rgba(255,255,255,0.8)',
+  marginBottom: '12px',
+}
+
+/** Panel header with justify-between */
+export const panelHeaderSpaced: CSSProperties = {
+  ...panelHeader,
+  justifyContent: 'space-between',
+}
+
+/** Refresh button in panel header */
+export const refreshBtn: CSSProperties = {
+  color: 'rgba(255,255,255,0.3)',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  transition: 'color 150ms',
+  display: 'flex',
+  alignItems: 'center',
+}
+
+/** Auto-label on right side of header — `ml-auto text-[10px] text-white/30 font-normal` */
+export const headerSubtext: CSSProperties = {
+  marginLeft: 'auto',
+  fontSize: '10px',
+  color: 'rgba(255,255,255,0.3)',
+  fontWeight: 400,
+}
+
+/** Stat box — `bg-white/5 rounded-lg px-3 py-2` */
+export const statBox: CSSProperties = {
+  background: 'rgba(255,255,255,0.05)',
+  borderRadius: '8px',
+  paddingLeft: '12px',
+  paddingRight: '12px',
+  paddingTop: '8px',
+  paddingBottom: '8px',
+}
+
+/** Stat label — `text-[10px] text-white/40` */
+export const statLabel: CSSProperties = {
+  fontSize: '10px',
+  color: 'rgba(255,255,255,0.4)',
+}
+
+/** Stat value — `text-lg font-bold tabular-nums text-white/80` */
+export const statValue: CSSProperties = {
+  fontSize: '18px',
+  fontWeight: 700,
+  fontVariantNumeric: 'tabular-nums',
+  color: 'rgba(255,255,255,0.8)',
+}
+
+/** Stat value highlight — `text-blue-400` */
+export const statValueHighlight: CSSProperties = {
+  ...statValue,
+  color: '#60a5fa',
+}
+
+/** Loading state — `text-white/30 text-xs flex items-center justify-center` */
+export const loadingState: CSSProperties = {
+  color: 'rgba(255,255,255,0.3)',
+  fontSize: '12px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+/** Error state with icon — `flex flex-col items-center justify-center gap-2 text-white/30` */
+export const errorState: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  color: 'rgba(255,255,255,0.3)',
+}
+
+/** Error detail — `text-xs text-center` */
+export const errorDetail: CSSProperties = {
+  fontSize: '12px',
+  textAlign: 'center',
+}
+
+/** Scope highlight — `text-white/60` */
+export const scopeHighlight: CSSProperties = {
+  color: 'rgba(255,255,255,0.6)',
+}
+
+/** Fine print — `text-[10px] text-white/20` */
+export const finePrint: CSSProperties = {
+  fontSize: '10px',
+  color: 'rgba(255,255,255,0.2)',
+  lineHeight: 1.6,
+}
+
+/** Section divider — `border-t border-white/10` */
+export const divider: CSSProperties = {
+  borderTop: '1px solid rgba(255,255,255,0.1)',
+  paddingTop: '12px',
+}
+
+/** Progress bar track — `h-2 bg-white/10 rounded-full overflow-hidden` */
+export const barTrack: CSSProperties = {
+  height: '8px',
+  background: 'rgba(255,255,255,0.1)',
+  borderRadius: '999px',
+  overflow: 'hidden',
+}
+
+/** Thin progress bar track — `h-1 bg-white/10 rounded-full overflow-hidden` */
+export const thinBarTrack: CSSProperties = {
+  height: '4px',
+  background: 'rgba(255,255,255,0.1)',
+  borderRadius: '999px',
+  overflow: 'hidden',
+}
+
+/** Primary text — `text-white/80` */
+export const textPrimary: CSSProperties = { color: 'rgba(255,255,255,0.8)' }
+
+/** Secondary text — `text-white/60` */
+export const textSecondary: CSSProperties = { color: 'rgba(255,255,255,0.6)' }
+
+/** Muted text — `text-white/40` */
+export const textMuted: CSSProperties = { color: 'rgba(255,255,255,0.4)' }
+
+/** Very muted text — `text-white/30` */
+export const textFaint: CSSProperties = { color: 'rgba(255,255,255,0.3)' }
+
+/** Tab button (active) */
+export const tabActive: CSSProperties = {
+  fontSize: '10px',
+  paddingLeft: '8px',
+  paddingRight: '8px',
+  paddingTop: '2px',
+  paddingBottom: '2px',
+  borderRadius: '4px',
+  background: 'rgba(59,130,246,0.3)',
+  color: 'rgb(147,197,253)',
+  border: 'none',
+  cursor: 'pointer',
+}
+
+/** Tab button (inactive) */
+export const tabInactive: CSSProperties = {
+  fontSize: '10px',
+  paddingLeft: '8px',
+  paddingRight: '8px',
+  paddingTop: '2px',
+  paddingBottom: '2px',
+  borderRadius: '4px',
+  color: 'rgba(255,255,255,0.3)',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  transition: 'color 150ms',
+}
+
+/** Grid 2 columns — `grid grid-cols-2 gap-3` */
+export const grid2: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '12px',
+}
+
+/** Grid responsive 2-4 columns */
+export const grid2to4: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '8px',
+}
+
+/** Flex row with gap */
+export const flexRow: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+}
+
+/** Space-y-2 equivalent */
+export const stackSm: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+}


### PR DESCRIPTION
- [x] Review feedback: Replace `Loader` icon (missing `@keyframes spin`) with FluentUI `Spinner` in `HubDashboard.tsx`
  - Imports `Spinner` from `@fluentui/react-components`
  - Removes `Loader` from `lucide-react` imports
  - Uses `<Spinner size="extra-small" />` for the refresh button loading state