### PR TITLE
fix: clarify branch policy guard comment (Copilot review follow-up from #86)

### DIFF
--- a/.github/workflows/ghaw-branch-policy-guard.yml
+++ b/.github/workflows/ghaw-branch-policy-guard.yml
@@ -1,7 +1,7 @@
 name: "GH-AW: Branch Policy Guard"
 
-# Enforces promotion flow: any branch -> staging -> main.
-# Staging accepts PRs from any branch; main only accepts staging.
+# Enforces only the final promotion step: staging -> main.
+# PRs into staging are unrestricted; PRs into main must come from staging.
 # Engagement Level: T1 (Observer) - validates PR branch topology only.
 
 on:


### PR DESCRIPTION
## What

Applies the Copilot review suggestion from PR #86 that was committed after the PR had already merged.

## Change

Updates the workflow header comment to accurately describe what the guard enforces:

**Before:**
\\\
# Enforces promotion flow: any branch -> staging -> main.
# Staging accepts PRs from any branch; main only accepts staging.
\\\

**After:**
\\\
# Enforces only the final promotion step: staging -> main.
# PRs into staging are unrestricted; PRs into main must come from staging.
\\\

The old wording implied the workflow validates both hops of the promotion flow. In reality (since #86), it only enforces \staging -> main\. This is a comment-only change — no logic is affected.

## Related

- Closes Copilot review thread from #86
- cx:exempt — comment-only change, no user-visible surface