### PR TITLE
chore: add changed-files guard workflow

### DIFF
--- a/.github/workflows/ghaw-changed-files-guard.yml
+++ b/.github/workflows/ghaw-changed-files-guard.yml
@@ -1,0 +1,19 @@
+name: ghaw-changed-files-guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changed-files-guard:
+    uses: AgentCraftworks/AgentCraftworks-PlatformOps/.github/workflows/ghaw-changed-files-guard-reusable.yml@main
+    with:
+      max_changed_files: 30
+      require_declared_files: false
+      declared_files_start_marker: "<!-- changed-files:start -->"
+      declared_files_end_marker: "<!-- changed-files:end -->"
+      allowed_prefixes: ""

--- a/.github/workflows/ghaw-changed-files-guard.yml
+++ b/.github/workflows/ghaw-changed-files-guard.yml
@@ -1,4 +1,4 @@
-name: ghaw-changed-files-guard
+name: "GH-AW: Changed Files Guard"
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
Add changed-files guard workflow caller referencing centralized reusable workflow in AgentCraftworks-PlatformOps.

## Notes
- Target branch: staging
- Scope: workflow guard only
- cx:exempt (internal workflow hygiene)