### PR TITLE
chore(agents): add git hygiene mandatory guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,38 @@ AgentCraftworks-Hub/
 └── AGENTS.md
 ```
 
+## Definition of Done — Customer Experience (MANDATORY)
+
+> **⚠️ API tests passing alone does NOT constitute "done."**
+> A feature is only complete when a real customer can experience it and that experience has been validated with real product screenshots.
+
+### How CX validation is triggered — the `cx:required` label
+
+Not every PR produces a tangible customer-facing outcome. To keep the standard meaningful without blocking unrelated work:
+
+- **Label issues and PRs with `cx:required`** when the work directly produces or modifies a customer-visible experience.
+- Work **without** `cx:required` must carry `cx:exempt` **and** a one-line justification in the PR description (e.g., "backend-only refactor", "partial implementation — CX tracked in #456").
+- Author or maintainer can apply `cx:exempt`. **When in doubt, apply `cx:required`.**
+
+### Blocking requirements for all PRs
+
+- [ ] Unit tests pass
+- [ ] TypeScript compiles clean
+- [ ] ESLint passes
+- [ ] PR reviewed and approved
+- [ ] PR is labelled **either** `cx:required` **or** `cx:exempt` (with justification)
+
+### Additional blocking requirements for `cx:required` work
+
+> These only apply when the PR or linked issue carries the `cx:required` label.
+
+- [ ] **CX capture spec exists** — `RecordingStudio/capture-specs/<feature-slug>.yaml` with `source_app`, `pass_criteria`, and real product selectors
+- [ ] **CX synthetic test passes** — Playwright automation runs against the real running product; all `pass_criteria` assertions succeed
+- [ ] **CX demo capture exists** — at least one screenshot or screen recording showing the feature from a customer perspective (real product only, no mocks)
+- [ ] **Demo slug added to `cx-capture.yml`** — so the feature stays validated on every weekly CX synthetic run going forward
+
+Full tooling instructions: `AgentCraftworks/RecordingStudio/AGENTS.md`
+
 ## Coding Conventions
 
 - **Runtime**: Node.js 22+ with CommonJS in scripts, ES Modules in src/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,52 @@ feature/|feat/|fix/|hotfix/|chore/|docs/* → staging → main → v* tag → Gi
 | `ghaw-build-deploy.yml` | Push to staging/main, `v*` tags, or manual dispatch | Unified build: staging (unpacked dirs), production (full installers), or release (publish to GitHub Releases) |
 | `ghaw-staging-refresh.yml` | staging→main PR merged | Resets staging to match main |
 
+## Agent Session Git Hygiene (MANDATORY)
+
+> **❌ `git add .` IS PROHIBITED.** Never use it. It can sweep up thousands of untracked generated or scratch files into your commit, producing PRs with thousands of unintended files. Always stage with explicit paths: `git add <file1> <file2> ...`
+>
+> **Required before any `git add`:** Run `git status --short` and read every line. Files marked `??` are untracked — they must be verified as intentional before staging. If you see paths you did not create as part of this task, do NOT stage them.
+
+### Pre-staging scope check (MANDATORY — do this before every `git add`)
+
+```bash
+# 1. See exactly what you're about to stage
+git status --short
+
+# 2. Verify scope — if > ~15 files or any unexpected ?? lines, stop and investigate
+#    Do NOT stage scratch files, generated dirs, or files you didn't create
+
+# 3. Stage ONLY the files that are part of this task — by explicit path
+git add path/to/file1 path/to/file2
+
+# 4. Confirm what is actually staged before committing
+git diff --cached --stat
+#    If this shows more files than intended: git restore --staged <unwanted-file>
+```
+
+### ⚠️ Never commit to main or staging directly
+
+Verify your branch before any git operation:
+
+```bash
+git branch --show-current   # Must NOT be 'main' or 'staging'
+```
+
+If it is: **STOP** immediately. Create a feature branch first — `git checkout -b feat/<description>`.
+
+### Commit checklist
+
+```
+- [ ] git branch --show-current → NOT main or staging
+- [ ] Build/type-check passes
+- [ ] git status --short → reviewed all lines, no unexpected ?? files
+- [ ] git add <file1> <file2> → EXPLICIT PATHS ONLY — NEVER git add .
+- [ ] git diff --cached --stat → staged count matches expectation
+- [ ] git commit -m "conventional commit message"
+- [ ] git push origin <branch>
+- [ ] gh pr create --base staging
+```
+
 ## Build & Run
 
 ```bash


### PR DESCRIPTION
Adds git hygiene section to AGENTS.md: prohibits git add ., adds pre-staging scope check, branch verification, and commit checklist. Propagated from AgentCraftworks/AGENTS.md (PR #1599).