### PR TITLE
chore: add acw-pr-readiness automation workflow

### DIFF
--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -1,0 +1,26 @@
+name: ACW PR Readiness
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  security-events: read
+
+jobs:
+  pr-readiness:
+    uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@main
+    with:
+      required_human_reviewer: jenperret
+      enforced_base_branches: staging,main
+      request_copilot_review: true
+      copilot_reviewer_candidates: copilot,github-copilot[bot]
+      escalation_label: needs-human-decision
+    secrets: inherit


### PR DESCRIPTION
## Summary
Adds the \cw-pr-readiness\ workflow to enable enterprise PR readiness automation.

## Gates enabled
- ✅ Auto-request reviewer: \@jenperret\ + Copilot
- ✅ Required human approval on \staging\ and \main\
- ✅ GHAS alert gate (blocks on open code-scanning alerts)
- ✅ Dependency review gate (blocks on moderate+ vulnerabilities)
- ✅ Review feedback gate (blocks on unresolved threads)
- ✅ Escalation label + comment on failure

## Part of
AgentCraftworks org pilot for enterprise PR readiness rollout.