### PR TITLE
fix: repair ACW PR readiness workflow

### DIFF
--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -16,6 +16,8 @@ jobs:
   pr-readiness:
     uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@main
     with:
+      pull_number: ${{ github.event.pull_request.number }}
+      trigger_action: ${{ github.event.action }}
       required_human_reviewer: jenperret
       enforced_base_branches: staging,main
       request_copilot_review: true

--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pr-readiness:
-    uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@main
+    uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@c73707373b824d682aa5f538f82e722cd58437c9
     with:
       pull_number: ${{ github.event.pull_request.number }}
       trigger_action: ${{ github.event.action }}

--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, reopened, synchronize, edited, ready_for_review, review_requested]
   pull_request_review:
     types: [submitted, edited, dismissed]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
 
 permissions:
   contents: read
@@ -16,10 +14,11 @@ permissions:
 
 jobs:
   pr-readiness:
-    uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@abe88f1a0dd7da73306bd06bf837f684789bde5e
+    uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@main
     with:
       required_human_reviewer: jenperret
       enforced_base_branches: staging,main
       request_copilot_review: true
       copilot_reviewer_candidates: copilot,github-copilot[bot]
       escalation_label: needs-human-decision
+    secrets: inherit

--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -23,4 +23,6 @@ jobs:
       request_copilot_review: true
       copilot_reviewer_candidates: copilot,github-copilot[bot]
       escalation_label: needs-human-decision
-    secrets: inherit
+    secrets:
+      GH_APP_ID: ${{ secrets.AGENTCRAFTWORKS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.AGENTCRAFTWORKS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Root cause
Recent ACW readiness runs failed before creating jobs (run IDs: 27477582553, 27477533466) due to a workflow-file issue. The workflow on `staging` included unsupported trigger `pull_request_review_thread`, which prevented required checks from starting.

## Fix
- Removed unsupported `pull_request_review_thread` trigger
- Kept required triggers:
  - `pull_request` types: opened, reopened, synchronize, edited, ready_for_review, review_requested
  - `pull_request_review` types: submitted, edited, dismissed
- Kept valid YAML top-level structure (`name`, `on`, `permissions`, `jobs`)
- Set required permissions:
  - `contents: read`
  - `pull-requests: write`
  - `issues: write`
  - `security-events: read`
- Updated reusable workflow reference to:
  - `AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@main`
- Restored `secrets: inherit`