### PR TITLE
chore: cancel in-flight duplicate PR readiness runs

### DIFF
--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   security-events: read
 
+concurrency:
+  group: acw-pr-readiness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-readiness:
     uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@c73707373b824d682aa5f538f82e722cd58437c9


### PR DESCRIPTION
Adds workflow concurrency to ACW PR Readiness so only the newest run per PR executes while keeping pull_request + pull_request_review gate coverage intact.